### PR TITLE
chore: update grcov to v0.10.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [
-          ubuntu-latest,
-          windows-latest,
-          macOS-latest
-        ]
+        os: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v6
@@ -30,4 +26,4 @@ jobs:
           toolchain: stable
 
       - name: Build
-        run: cargo build --release
+        run: cargo build --release --all-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install grcov
         run: |
           rustup component add llvm-tools-preview
-          cargo install grcov --version 0.8.20
+          cargo install grcov --version 0.10.7
 
       - name: Run tests
         run: cargo test --all-features


### PR DESCRIPTION
Bump grcov from 0.8.20 to 0.10.7 (latest).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

chore: remove Windows build and add --all-features

Drop Windows from the build matrix (not a target platform for server-side batch processing) and add --all-features for more meaningful compilation checks.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

remove mac build