### PR TITLE
chore: update GitHub Actions workflows to use current actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   clippy:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   fmt:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,6 @@ on:
           - minor
           - major
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
   issues: write
@@ -31,7 +28,7 @@ jobs:
         with:
           toolchain: stable
 
-      - name: publish crate
+      - name: Publish crate (dry run)
         run: cargo publish --dry-run
 
   release:
@@ -39,12 +36,12 @@ jobs:
     needs: publish-dry-run
     runs-on: ubuntu-latest
     steps:
-      - name: Generate Githup App Token
+      - name: Generate GitHub App Token
         id: generate_token
-        uses: tibdex/github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app_id: ${{ secrets.APP_ID }}
-          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
       - name: Checkout code
         uses: actions/checkout@v6
@@ -57,41 +54,36 @@ jobs:
         with:
           toolchain: stable
 
-      - name: Install `cargo-edit`
+      - name: Install cargo-edit
         run: cargo install cargo-edit
 
-      - id: cargo-set-version
-        name: Set Version
-        run: cargo set-version --bump ${{ inputs.version }}
+      - name: Bump version
+        env:
+          VERSION: ${{ inputs.version }}
+        run: cargo set-version --bump "$VERSION"
 
-      - name: Set Crate Version as Environment Variable
+      - name: Set crate version as environment variable
         run: |
           CARGO_TOML_VERSION=$(awk -F ' = ' '$1 ~ /version/ { gsub(/[\"]/, "", $2); printf("%s",$2) }' Cargo.toml)
           echo "CRATE_VERSION=$CARGO_TOML_VERSION" >> $GITHUB_ENV
 
-      - name: Create Commit
+      - name: Commit and push version bump
         run: |
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
           git add .
           git commit -m "chore: bump version to v$CRATE_VERSION"
+          git push
 
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ steps.generate_token.outputs.token }}
-          branch: ${{ github.ref }}
-
-      - name: Login to Crates.io
-        run: cargo login ${CARGO_REGISTRY_TOKEN}
+      - name: Login to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: cargo login "$CARGO_REGISTRY_TOKEN"
 
       - name: Publish crate
         run: cargo publish
 
-      - name: Create Release
-        id: create_release
+      - name: Create GitHub Release
         uses: actions/github-script@v9
         env:
           CRATE_VERSION: ${{ env.CRATE_VERSION }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,6 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

- Replace `tibdex/github-app-token@v2` with `actions/create-github-app-token@v3` (action officielle GitHub, Node.js 24) dans `release.yml`
- Supprimer `ad-m/github-push-action@master` (non versionné), remplacé par `git push` natif
- Supprimer `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` de tous les workflows — obsolète car `actions/checkout@v6` et `actions/cache@v5` sont déjà sur Node.js 24
- Utiliser des variables d'environnement pour les inputs `workflow_dispatch` (bonne pratique sécurité GitHub Actions)

## Test Plan

- [ ] Déclencher le workflow `Release` manuellement via `workflow_dispatch` pour valider le token GitHub App
- [ ] Vérifier que les workflows `fmt`, `clippy`, `test`, `build` passent sans erreur

🤖 Generated with [Claude Code](https://claude.com/claude-code)