### PR TITLE
fix(rdbc): suppress type_complexity lint on read_item

### DIFF
--- a/src/item/rdbc/reader_common.rs
+++ b/src/item/rdbc/reader_common.rs
@@ -76,6 +76,7 @@ pub fn should_load_page(page_index: i32) -> bool {
 /// # Errors
 ///
 /// Returns [`BatchError::ItemReader`] if `load_page` fails.
+#[allow(clippy::type_complexity)]
 pub fn read_item<I: Clone>(
     offset: &Cell<i32>,
     page_size: Option<i32>,


### PR DESCRIPTION
## Summary

Add `#[allow(clippy::type_complexity)]` to `read_item` in `reader_common` — the `Option<Box<dyn Fn(&I) -> String>>` parameter triggers the lint but is idiomatic here, consistent with the `#[allow]` on the struct fields in all three readers.

## Test Plan

- [ ] `cargo clippy --all-features -- -D warnings` — zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)