### PR TITLE
feat(rdbc): column mapping API, SelectBuilder, keyset perf + benchmark refactor

### DIFF
--- a/docs/superpowers/plans/2026-05-15-rdbc-column-mapping.md
+++ b/docs/superpowers/plans/2026-05-15-rdbc-column-mapping.md
@@ -1,0 +1,2287 @@
+# RDBC Column Mapping API Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `DatabaseItemBinder<O, DB>` trait with a fluent `.column(name, extractor)` API on `RdbcItemWriterBuilder`, eliminating boilerplate and database-specific binder structs.
+
+**Architecture:** A new `ColumnValue` enum (Int, Float, Text, Bool, Bytes, Null) with `From` impls for all primitive types and `Option<T>` acts as a type-erased value carrier. Writer structs store `column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>` instead of an `item_binder` reference; at write time, each closure is called and the result dispatched to `push_bind` with the concrete primitive type. The `DatabaseItemBinder` trait, all three binder fields on the builder, `add_column`, and `validate_config` are removed entirely.
+
+**Tech Stack:** Rust 2021, sqlx (QueryBuilder, push_bind, push_values), tokio (block_in_place)
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/item/rdbc/column_value.rs` | **Create** — `ColumnValue` enum + `From` impls |
+| `src/item/rdbc/writer_common.rs` | **Modify** — delete `DatabaseItemBinder`, update `validate_config` signature (no binder param), update tests |
+| `src/item/rdbc/sqlite_writer.rs` | **Modify** — replace `item_binder` with `column_bindings`, update `write()` |
+| `src/item/rdbc/postgres_writer.rs` | **Modify** — same as sqlite_writer |
+| `src/item/rdbc/mysql_writer.rs` | **Modify** — same as sqlite_writer |
+| `src/item/rdbc/unified_writer_builder.rs` | **Modify** — add `.column()`, remove binder fields/methods/`add_column` |
+| `src/item/rdbc/mod.rs` | **Modify** — add `column_value` module, export `ColumnValue`, remove `DatabaseItemBinder` |
+| `tests/helpers/sqlite_helpers.rs` | **Modify** — remove `SqliteCarItemBinder`, keep `Car` |
+| `tests/helpers/postgres_helpers.rs` | **Modify** — remove `PostgresCarItemBinder`, keep `Car` |
+| `tests/helpers/mysql_helpers.rs` | **Modify** — remove `MySqlCarItemBinder`, keep `Car` |
+| `tests/rdbc_sqlite.rs` | **Modify** — rewrite writer test with `.column()`, add nullable test |
+| `tests/rdbc_postgres.rs` | **Modify** — rewrite writer test with `.column()`, add nullable test |
+| `tests/rdbc_mysql.rs` | **Modify** — rewrite writer test with `.column()`, add nullable test |
+| `examples/database_processing.rs` | **Modify** — replace binder structs with `.column()` calls |
+| `examples/benchmark_csv_postgres_xml.rs` | **Modify** — replace binder structs with `.column()` calls |
+
+---
+
+## Task 1: Create `ColumnValue` enum with `From` impls and unit tests
+
+**Files:**
+- Create: `src/item/rdbc/column_value.rs`
+
+- [ ] **Step 1: Write the failing unit tests first**
+
+Create `src/item/rdbc/column_value.rs` with only the test module (no impl yet):
+
+```rust
+//! Type-erased column value for RDBC item writers.
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_convert_i32_to_int() {
+        assert!(matches!(ColumnValue::from(42i32), ColumnValue::Int(42)));
+    }
+
+    #[test]
+    fn should_convert_i64_to_int() {
+        assert!(matches!(ColumnValue::from(100i64), ColumnValue::Int(100)));
+    }
+
+    #[test]
+    fn should_convert_f32_to_float() {
+        let v = ColumnValue::from(1.5f32);
+        assert!(matches!(v, ColumnValue::Float(_)));
+        if let ColumnValue::Float(f) = v {
+            assert!((f - 1.5f64).abs() < 1e-5, "f32 should be widened to f64");
+        }
+    }
+
+    #[test]
+    fn should_convert_f64_to_float() {
+        assert!(matches!(ColumnValue::from(3.14f64), ColumnValue::Float(_)));
+    }
+
+    #[test]
+    fn should_convert_bool_to_bool() {
+        assert!(matches!(ColumnValue::from(true), ColumnValue::Bool(true)));
+        assert!(matches!(ColumnValue::from(false), ColumnValue::Bool(false)));
+    }
+
+    #[test]
+    fn should_convert_str_to_text() {
+        assert!(matches!(ColumnValue::from("hello"), ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_string_to_text() {
+        assert!(matches!(
+            ColumnValue::from("world".to_string()),
+            ColumnValue::Text(_)
+        ));
+    }
+
+    #[test]
+    fn should_convert_bytes_to_bytes() {
+        let v = ColumnValue::from(vec![1u8, 2, 3]);
+        assert!(matches!(v, ColumnValue::Bytes(_)));
+    }
+
+    #[test]
+    fn should_convert_some_i32_to_int() {
+        assert!(matches!(
+            ColumnValue::from(Some(7i32)),
+            ColumnValue::Int(7)
+        ));
+    }
+
+    #[test]
+    fn should_convert_none_i32_to_null() {
+        assert!(matches!(ColumnValue::from(None::<i32>), ColumnValue::Null));
+    }
+
+    #[test]
+    fn should_convert_some_string_to_text() {
+        let v = ColumnValue::from(Some("abc".to_string()));
+        assert!(matches!(v, ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_none_string_to_null() {
+        assert!(matches!(
+            ColumnValue::from(None::<String>),
+            ColumnValue::Null
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cargo test --features rdbc-sqlite column_value 2>&1 | head -30
+```
+
+Expected: compile error — `ColumnValue` not defined.
+
+- [ ] **Step 3: Implement `ColumnValue` and all `From` impls**
+
+Replace the file content with:
+
+```rust
+//! Type-erased column value for RDBC item writers.
+
+/// A type-erased value that can be bound to a database column.
+///
+/// Used by [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column)
+/// to carry field values from item extractor closures to `push_bind` at write time.
+///
+/// # Examples
+///
+/// ```
+/// use spring_batch_rs::item::rdbc::ColumnValue;
+///
+/// let v: ColumnValue = 42i32.into();
+/// assert!(matches!(v, ColumnValue::Int(42)));
+///
+/// let v: ColumnValue = None::<i32>.into();
+/// assert!(matches!(v, ColumnValue::Null));
+/// ```
+pub enum ColumnValue {
+    /// Signed integer (covers i32, i64).
+    Int(i64),
+    /// Floating-point number (covers f32, f64).
+    Float(f64),
+    /// UTF-8 text (covers &str, String).
+    Text(String),
+    /// Boolean value.
+    Bool(bool),
+    /// Raw bytes.
+    Bytes(Vec<u8>),
+    /// SQL NULL — produced by Option::None.
+    Null,
+}
+
+impl From<i32> for ColumnValue {
+    fn from(v: i32) -> Self { ColumnValue::Int(v as i64) }
+}
+
+impl From<i64> for ColumnValue {
+    fn from(v: i64) -> Self { ColumnValue::Int(v) }
+}
+
+impl From<f32> for ColumnValue {
+    fn from(v: f32) -> Self { ColumnValue::Float(v as f64) }
+}
+
+impl From<f64> for ColumnValue {
+    fn from(v: f64) -> Self { ColumnValue::Float(v) }
+}
+
+impl From<bool> for ColumnValue {
+    fn from(v: bool) -> Self { ColumnValue::Bool(v) }
+}
+
+impl From<&str> for ColumnValue {
+    fn from(v: &str) -> Self { ColumnValue::Text(v.to_string()) }
+}
+
+impl From<String> for ColumnValue {
+    fn from(v: String) -> Self { ColumnValue::Text(v) }
+}
+
+impl From<Vec<u8>> for ColumnValue {
+    fn from(v: Vec<u8>) -> Self { ColumnValue::Bytes(v) }
+}
+
+impl<T: Into<ColumnValue>> From<Option<T>> for ColumnValue {
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(inner) => inner.into(),
+            None => ColumnValue::Null,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_convert_i32_to_int() {
+        assert!(matches!(ColumnValue::from(42i32), ColumnValue::Int(42)));
+    }
+
+    #[test]
+    fn should_convert_i64_to_int() {
+        assert!(matches!(ColumnValue::from(100i64), ColumnValue::Int(100)));
+    }
+
+    #[test]
+    fn should_convert_f32_to_float() {
+        let v = ColumnValue::from(1.5f32);
+        assert!(matches!(v, ColumnValue::Float(_)));
+        if let ColumnValue::Float(f) = v {
+            assert!((f - 1.5f64).abs() < 1e-5, "f32 should be widened to f64");
+        }
+    }
+
+    #[test]
+    fn should_convert_f64_to_float() {
+        assert!(matches!(ColumnValue::from(3.14f64), ColumnValue::Float(_)));
+    }
+
+    #[test]
+    fn should_convert_bool_to_bool() {
+        assert!(matches!(ColumnValue::from(true), ColumnValue::Bool(true)));
+        assert!(matches!(ColumnValue::from(false), ColumnValue::Bool(false)));
+    }
+
+    #[test]
+    fn should_convert_str_to_text() {
+        assert!(matches!(ColumnValue::from("hello"), ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_string_to_text() {
+        assert!(matches!(
+            ColumnValue::from("world".to_string()),
+            ColumnValue::Text(_)
+        ));
+    }
+
+    #[test]
+    fn should_convert_bytes_to_bytes() {
+        let v = ColumnValue::from(vec![1u8, 2, 3]);
+        assert!(matches!(v, ColumnValue::Bytes(_)));
+    }
+
+    #[test]
+    fn should_convert_some_i32_to_int() {
+        assert!(matches!(
+            ColumnValue::from(Some(7i32)),
+            ColumnValue::Int(7)
+        ));
+    }
+
+    #[test]
+    fn should_convert_none_i32_to_null() {
+        assert!(matches!(ColumnValue::from(None::<i32>), ColumnValue::Null));
+    }
+
+    #[test]
+    fn should_convert_some_string_to_text() {
+        let v = ColumnValue::from(Some("abc".to_string()));
+        assert!(matches!(v, ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_none_string_to_null() {
+        assert!(matches!(
+            ColumnValue::from(None::<String>),
+            ColumnValue::Null
+        ));
+    }
+}
+```
+
+- [ ] **Step 4: Wire the module in `mod.rs`**
+
+In `src/item/rdbc/mod.rs`, add before the existing module declarations:
+
+```rust
+/// Type-erased column value for item writers.
+mod column_value;
+```
+
+And add to the re-exports section (after `pub use select_builder::SelectBuilder;`):
+
+```rust
+pub use column_value::ColumnValue;
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cargo test --features rdbc-sqlite column_value 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 12 passed`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/item/rdbc/column_value.rs src/item/rdbc/mod.rs
+git commit -m "feat(rdbc): add ColumnValue enum with From impls for column binding"
+```
+
+---
+
+## Task 2: Update `writer_common.rs` — remove `DatabaseItemBinder`, simplify `validate_config`
+
+**Files:**
+- Modify: `src/item/rdbc/writer_common.rs`
+
+The current `validate_config` takes `item_binder` as a parameter and returns it. With the new API, there is no binder — validation only checks pool, table, and that column_bindings is non-empty. The function signature changes; all three writer files that call it must be updated in the same task.
+
+- [ ] **Step 1: Write the new `validate_config` tests**
+
+The existing tests in `writer_common.rs` test the old signature. Replace only the binder-related tests. The new `validate_config` signature is:
+
+```rust
+pub fn validate_config<'a, DB: Database>(
+    pool: Option<&'a Pool<DB>>,
+    table: Option<&'a str>,
+    column_count: usize,
+) -> Result<(&'a Pool<DB>, &'a str), BatchError>
+```
+
+The new tests (replace the existing four `validate_config` tests with these):
+
+```rust
+#[test]
+fn should_return_error_when_columns_is_empty() {
+    let result = validate_config::<Sqlite>(None, Some("tbl"), 0);
+    match result.err().unwrap() {
+        BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "unexpected: {msg}"),
+        e => panic!("expected ItemWriter, got {e:?}"),
+    }
+}
+
+#[test]
+fn should_return_error_when_pool_is_missing() {
+    let result = validate_config::<Sqlite>(None, Some("tbl"), 1);
+    match result.err().unwrap() {
+        BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "unexpected: {msg}"),
+        e => panic!("expected ItemWriter, got {e:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_return_error_when_table_is_missing() {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let result = validate_config::<Sqlite>(Some(&pool), None, 1);
+    match result.err().unwrap() {
+        BatchError::ItemWriter(msg) => assert!(msg.contains("Table"), "unexpected: {msg}"),
+        e => panic!("expected ItemWriter, got {e:?}"),
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_return_ok_when_all_config_provided() {
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let result = validate_config::<Sqlite>(Some(&pool), Some("tbl"), 1);
+    assert!(result.is_ok(), "should return Ok when all config is provided");
+}
+```
+
+- [ ] **Step 2: Update `writer_common.rs`**
+
+Replace the entire file content (keep `BIND_LIMIT`, `log_write_success`, `create_write_error`, `max_items_per_batch` unchanged; update only `ValidatedConfig`, `validate_config`, and the module-level `//!` to remove the `DatabaseItemBinder` mention, and remove the `use crate::item::rdbc::DatabaseItemBinder` import from tests):
+
+```rust
+//! Common functionality for database item writers.
+//!
+//! Provides shared utilities used across PostgreSQL, MySQL, and SQLite writers.
+
+use crate::BatchError;
+use sqlx::{Database, Pool};
+
+/// The maximum number of parameters bound in a single SQL statement.
+/// This is the most conservative limit across major databases (MySQL's limit).
+pub const BIND_LIMIT: usize = 65535;
+
+/// Type alias for the validated configuration returned by [`validate_config`].
+type ValidatedConfig<'a, DB> = (&'a Pool<DB>, &'a str);
+
+/// Validates that all required writer configuration fields are set.
+///
+/// # Errors
+///
+/// Returns [`BatchError::ItemWriter`] if columns is zero, pool is `None`, or table is `None`.
+pub fn validate_config<'a, DB: Database>(
+    pool: Option<&'a Pool<DB>>,
+    table: Option<&'a str>,
+    column_count: usize,
+) -> Result<ValidatedConfig<'a, DB>, BatchError> {
+    if column_count == 0 {
+        return Err(BatchError::ItemWriter(
+            "No columns specified for database write".to_string(),
+        ));
+    }
+
+    let pool =
+        pool.ok_or_else(|| BatchError::ItemWriter("Database pool not configured".to_string()))?;
+
+    let table =
+        table.ok_or_else(|| BatchError::ItemWriter("Table name not configured".to_string()))?;
+
+    Ok((pool, table))
+}
+
+/// Logs a successful write operation.
+#[inline]
+pub fn log_write_success(items_count: usize, table: &str, db_name: &str) {
+    log::debug!(
+        "Successfully wrote {} items to {} table {}",
+        items_count,
+        db_name,
+        table
+    );
+}
+
+/// Creates a database write error.
+///
+/// # Returns
+///
+/// A [`BatchError::ItemWriter`] with a formatted error message.
+pub fn create_write_error(table: &str, db_name: &str, error: impl std::fmt::Display) -> BatchError {
+    log::error!(
+        "Failed to write items to {} table {}: {}",
+        db_name,
+        table,
+        error
+    );
+    BatchError::ItemWriter(format!("{} write failed: {}", db_name, error))
+}
+
+/// Calculates the maximum number of items per batch given the bind limit.
+///
+/// # Returns
+///
+/// `BIND_LIMIT / column_count`
+#[inline]
+pub fn max_items_per_batch(column_count: usize) -> usize {
+    BIND_LIMIT / column_count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BatchError;
+    use sqlx::Sqlite;
+
+    #[test]
+    fn should_compute_max_items_per_batch() {
+        assert_eq!(max_items_per_batch(1), 65535);
+        assert_eq!(max_items_per_batch(2), 32767);
+        assert_eq!(max_items_per_batch(10), 6553);
+        assert_eq!(max_items_per_batch(100), 655);
+    }
+
+    #[test]
+    fn should_define_bind_limit_as_65535() {
+        assert_eq!(BIND_LIMIT, 65535);
+    }
+
+    #[test]
+    fn should_return_error_when_columns_is_empty() {
+        let result = validate_config::<Sqlite>(None, Some("tbl"), 0);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "unexpected: {msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_error_when_pool_is_missing() {
+        let result = validate_config::<Sqlite>(None, Some("tbl"), 1);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "unexpected: {msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_return_error_when_table_is_missing() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let result = validate_config::<Sqlite>(Some(&pool), None, 1);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("Table"), "unexpected: {msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_return_ok_when_all_config_provided() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let result = validate_config::<Sqlite>(Some(&pool), Some("tbl"), 1);
+        assert!(result.is_ok(), "should return Ok when all config is provided");
+    }
+
+    #[test]
+    fn should_call_log_write_success_without_panic() {
+        log_write_success(42, "users", "PostgreSQL");
+    }
+
+    #[test]
+    fn should_create_write_error_with_formatted_message() {
+        let err = create_write_error("orders", "MySQL", "connection refused");
+        match err {
+            BatchError::ItemWriter(msg) => {
+                assert!(msg.contains("MySQL"), "missing db name: {msg}");
+                assert!(msg.contains("connection refused"), "missing cause: {msg}");
+            }
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run `writer_common` tests (they will fail because writers still use old signature)**
+
+```bash
+cargo test --features rdbc-sqlite writer_common 2>&1 | tail -10
+```
+
+Expected: `test result: ok` for this file's tests. Compile errors in `postgres_writer`, `mysql_writer`, `sqlite_writer` are expected and will be fixed in Tasks 3-5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/item/rdbc/writer_common.rs
+git commit -m "refactor(rdbc): simplify validate_config — remove DatabaseItemBinder parameter"
+```
+
+---
+
+## Task 3: Rewrite `sqlite_writer.rs` with `column_bindings`
+
+**Files:**
+- Modify: `src/item/rdbc/sqlite_writer.rs`
+
+- [ ] **Step 1: Replace the entire file**
+
+The struct loses its `'a` lifetime and `item_binder` field. It gains `column_bindings`. The `write()` implementation calls `validate_config` with the new 3-argument signature and dispatches `ColumnValue` variants to `push_bind`.
+
+```rust
+use serde::Serialize;
+use sqlx::{Pool, QueryBuilder, Sqlite};
+
+use crate::core::item::{ItemWriter, ItemWriterResult};
+use crate::item::rdbc::ColumnValue;
+
+use super::writer_common::{
+    create_write_error, log_write_success, max_items_per_batch, validate_config,
+};
+
+/// A writer for inserting items into a SQLite database using SQLx.
+///
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
+///
+/// # Construction
+///
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
+///
+/// # Examples
+///
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::SqlitePool;
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Serialize)]
+/// struct Task { id: i32, title: String }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = SqlitePool::connect("sqlite::memory:").await?;
+///
+/// let writer = RdbcItemWriterBuilder::<Task>::new()
+///     .sqlite(&pool)
+///     .table("tasks")
+///     .column("id", |t: &Task| t.id.into())
+///     .column("title", |t: &Task| t.title.as_str().into())
+///     .build_sqlite();
+/// # Ok(())
+/// # }
+/// ```
+pub struct SqliteItemWriter<O> {
+    pool: Option<sqlx::Pool<Sqlite>>,
+    table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+}
+
+impl<O> SqliteItemWriter<O> {
+    pub(crate) fn new() -> Self {
+        Self {
+            pool: None,
+            table: None,
+            column_bindings: Vec::new(),
+        }
+    }
+
+    pub(crate) fn pool(mut self, pool: &Pool<Sqlite>) -> Self {
+        self.pool = Some(pool.clone());
+        self
+    }
+
+    pub(crate) fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
+        self
+    }
+
+    pub(crate) fn add_column_binding(
+        mut self,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
+    ) -> Self {
+        self.column_bindings.push((name, extractor));
+        self
+    }
+}
+
+impl<O> Default for SqliteItemWriter<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<O> {
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        let col_names: Vec<&str> = self.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+
+        let mut query_builder = QueryBuilder::new("INSERT INTO ");
+        query_builder.push(table);
+        query_builder.push(" (");
+        query_builder.push(col_names.join(","));
+        query_builder.push(") ");
+
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
+        let items_count = items_to_write.len();
+
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => { b.push_bind(v); }
+                    ColumnValue::Float(v) => { b.push_bind(v); }
+                    ColumnValue::Text(v) => { b.push_bind(v); }
+                    ColumnValue::Bool(v) => { b.push_bind(v); }
+                    ColumnValue::Bytes(v) => { b.push_bind(v); }
+                    ColumnValue::Null => { b.push_bind(Option::<String>::None); }
+                }
+            }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "SQLite");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "SQLite", e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::item::ItemWriter;
+    use crate::item::rdbc::ColumnValue;
+
+    #[test]
+    fn should_start_with_empty_state() {
+        let writer = SqliteItemWriter::<String>::new();
+        assert!(writer.pool.is_none());
+        assert!(writer.table.is_none());
+        assert!(writer.column_bindings.is_empty());
+    }
+
+    #[test]
+    fn should_store_column_bindings_in_order() {
+        let writer = SqliteItemWriter::<String>::new()
+            .table("t")
+            .add_column_binding("a".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("b".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"], "bindings should preserve insertion order");
+    }
+
+    #[test]
+    fn should_return_ok_for_empty_items() {
+        let writer = SqliteItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
+    }
+
+    #[test]
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = SqliteItemWriter::<String>::new().table("t");
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
+        let writer = SqliteItemWriter::<String>::new()
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_write_items_to_in_memory_sqlite() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE t (v TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let writer = SqliteItemWriter::<String>::new()
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        writer.write(&["hello".to_string(), "world".to_string()]).unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 2, "both items should have been written");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_return_error_when_query_fails() {
+        use crate::BatchError;
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let writer = SqliteItemWriter::<String>::new()
+            .pool(&pool)
+            .table("nonexistent_table")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("SQLite"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_write_null_for_none_optional_column() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER NOT NULL, note TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        #[derive(Clone, serde::Serialize)]
+        struct Row { id: i32, note: Option<String> }
+
+        let writer = SqliteItemWriter::<Row>::new()
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("id".to_string(), Box::new(|r: &Row| r.id.into()))
+            .add_column_binding(
+                "note".to_string(),
+                Box::new(|r: &Row| r.note.clone().into()),
+            );
+
+        writer
+            .write(&[Row { id: 1, note: None }])
+            .unwrap();
+
+        let (note,): (Option<String>,) = sqlx::query_as("SELECT note FROM t WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(note.is_none(), "note should be NULL in the database");
+    }
+}
+```
+
+- [ ] **Step 2: Run SQLite writer tests**
+
+```bash
+cargo test --features rdbc-sqlite sqlite_writer 2>&1 | tail -15
+```
+
+Expected: `test result: ok. 7 passed`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/item/rdbc/sqlite_writer.rs
+git commit -m "feat(rdbc): replace item_binder with column_bindings in SqliteItemWriter"
+```
+
+---
+
+## Task 4: Rewrite `postgres_writer.rs` with `column_bindings`
+
+**Files:**
+- Modify: `src/item/rdbc/postgres_writer.rs`
+
+- [ ] **Step 1: Replace the entire file**
+
+```rust
+use serde::Serialize;
+use sqlx::{Pool, Postgres, QueryBuilder};
+
+use crate::core::item::{ItemWriter, ItemWriterResult};
+use crate::item::rdbc::ColumnValue;
+
+use super::writer_common::{
+    create_write_error, log_write_success, max_items_per_batch, validate_config,
+};
+
+/// A writer for inserting items into a PostgreSQL database using SQLx.
+///
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
+///
+/// # Construction
+///
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
+///
+/// # Examples
+///
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::PgPool;
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Serialize)]
+/// struct User { id: i32, name: String }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+///
+/// let writer = RdbcItemWriterBuilder::<User>::new()
+///     .postgres(&pool)
+///     .table("users")
+///     .column("id", |u: &User| u.id.into())
+///     .column("name", |u: &User| u.name.as_str().into())
+///     .build_postgres();
+/// # Ok(())
+/// # }
+/// ```
+pub struct PostgresItemWriter<O> {
+    pub(crate) pool: Option<sqlx::Pool<Postgres>>,
+    pub(crate) table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+}
+
+impl<O> PostgresItemWriter<O> {
+    pub(crate) fn new() -> Self {
+        Self {
+            pool: None,
+            table: None,
+            column_bindings: Vec::new(),
+        }
+    }
+
+    pub(crate) fn pool(mut self, pool: &Pool<Postgres>) -> Self {
+        self.pool = Some(pool.clone());
+        self
+    }
+
+    pub(crate) fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
+        self
+    }
+
+    pub(crate) fn add_column_binding(
+        mut self,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
+    ) -> Self {
+        self.column_bindings.push((name, extractor));
+        self
+    }
+}
+
+impl<O> Default for PostgresItemWriter<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        let col_names: Vec<&str> = self.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+
+        let mut query_builder = QueryBuilder::new("INSERT INTO ");
+        query_builder.push(table);
+        query_builder.push(" (");
+        query_builder.push(col_names.join(","));
+        query_builder.push(") ");
+
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
+        let items_count = items_to_write.len();
+
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => { b.push_bind(v); }
+                    ColumnValue::Float(v) => { b.push_bind(v); }
+                    ColumnValue::Text(v) => { b.push_bind(v); }
+                    ColumnValue::Bool(v) => { b.push_bind(v); }
+                    ColumnValue::Bytes(v) => { b.push_bind(v); }
+                    ColumnValue::Null => { b.push_bind(Option::<String>::None); }
+                }
+            }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "PostgreSQL");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::rdbc::ColumnValue;
+
+    #[test]
+    fn should_start_with_empty_state() {
+        let writer = PostgresItemWriter::<String>::new();
+        assert!(writer.pool.is_none());
+        assert!(writer.table.is_none());
+        assert!(writer.column_bindings.is_empty());
+    }
+
+    #[test]
+    fn should_store_column_bindings_in_order() {
+        let writer = PostgresItemWriter::<String>::new()
+            .add_column_binding("x".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("y".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn should_return_ok_for_empty_items() {
+        let writer = PostgresItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
+    }
+
+    #[test]
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = PostgresItemWriter::<String>::new().table("t");
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
+        let writer = PostgresItemWriter::<String>::new()
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run Postgres writer tests**
+
+```bash
+cargo test --features rdbc-postgres postgres_writer 2>&1 | tail -15
+```
+
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/item/rdbc/postgres_writer.rs
+git commit -m "feat(rdbc): replace item_binder with column_bindings in PostgresItemWriter"
+```
+
+---
+
+## Task 5: Rewrite `mysql_writer.rs` with `column_bindings`
+
+**Files:**
+- Modify: `src/item/rdbc/mysql_writer.rs`
+
+- [ ] **Step 1: Replace the entire file**
+
+```rust
+use serde::Serialize;
+use sqlx::{MySql, Pool, QueryBuilder};
+
+use crate::core::item::{ItemWriter, ItemWriterResult};
+use crate::item::rdbc::ColumnValue;
+
+use super::writer_common::{
+    create_write_error, log_write_success, max_items_per_batch, validate_config,
+};
+
+/// A writer for inserting items into a MySQL database using SQLx.
+///
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
+///
+/// # Construction
+///
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
+///
+/// # Examples
+///
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::MySqlPool;
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Serialize)]
+/// struct Product { id: i32, name: String, price: f64 }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
+///
+/// let writer = RdbcItemWriterBuilder::<Product>::new()
+///     .mysql(&pool)
+///     .table("products")
+///     .column("id", |p: &Product| p.id.into())
+///     .column("name", |p: &Product| p.name.as_str().into())
+///     .column("price", |p: &Product| p.price.into())
+///     .build_mysql();
+/// # Ok(())
+/// # }
+/// ```
+pub struct MySqlItemWriter<O> {
+    pub(crate) pool: Option<sqlx::Pool<MySql>>,
+    pub(crate) table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+}
+
+impl<O> MySqlItemWriter<O> {
+    pub(crate) fn new() -> Self {
+        Self {
+            pool: None,
+            table: None,
+            column_bindings: Vec::new(),
+        }
+    }
+
+    pub(crate) fn pool(mut self, pool: &Pool<MySql>) -> Self {
+        self.pool = Some(pool.clone());
+        self
+    }
+
+    pub(crate) fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
+        self
+    }
+
+    pub(crate) fn add_column_binding(
+        mut self,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
+    ) -> Self {
+        self.column_bindings.push((name, extractor));
+        self
+    }
+}
+
+impl<O> Default for MySqlItemWriter<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        let col_names: Vec<&str> = self.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+
+        let mut query_builder = QueryBuilder::new("INSERT INTO ");
+        query_builder.push(table);
+        query_builder.push(" (");
+        query_builder.push(col_names.join(","));
+        query_builder.push(") ");
+
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
+        let items_count = items_to_write.len();
+
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => { b.push_bind(v); }
+                    ColumnValue::Float(v) => { b.push_bind(v); }
+                    ColumnValue::Text(v) => { b.push_bind(v); }
+                    ColumnValue::Bool(v) => { b.push_bind(v); }
+                    ColumnValue::Bytes(v) => { b.push_bind(v); }
+                    ColumnValue::Null => { b.push_bind(Option::<String>::None); }
+                }
+            }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "MySQL");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "MySQL", e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::item::rdbc::ColumnValue;
+
+    #[test]
+    fn should_start_with_empty_state() {
+        let writer = MySqlItemWriter::<String>::new();
+        assert!(writer.pool.is_none());
+        assert!(writer.table.is_none());
+        assert!(writer.column_bindings.is_empty());
+    }
+
+    #[test]
+    fn should_store_column_bindings_in_order() {
+        let writer = MySqlItemWriter::<String>::new()
+            .add_column_binding("a".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("b".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["a", "b"]);
+    }
+
+    #[test]
+    fn should_return_ok_for_empty_items() {
+        let writer = MySqlItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
+    }
+
+    #[test]
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = MySqlItemWriter::<String>::new().table("t");
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[test]
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
+        let writer = MySqlItemWriter::<String>::new()
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run MySQL writer tests**
+
+```bash
+cargo test --features rdbc-mysql mysql_writer 2>&1 | tail -15
+```
+
+Expected: `test result: ok. 5 passed`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/item/rdbc/mysql_writer.rs
+git commit -m "feat(rdbc): replace item_binder with column_bindings in MySqlItemWriter"
+```
+
+---
+
+## Task 6: Rewrite `unified_writer_builder.rs` — add `.column()`, remove binder API
+
+**Files:**
+- Modify: `src/item/rdbc/unified_writer_builder.rs`
+
+The builder gains `column_bindings`, loses `postgres_binder`/`mysql_binder`/`sqlite_binder` fields and methods and `add_column`. The `build_*` methods forward `column_bindings` via `add_column_binding` calls.
+
+- [ ] **Step 1: Replace the entire file**
+
+```rust
+use sqlx::{MySql, Pool, Postgres, Sqlite};
+
+use super::column_value::ColumnValue;
+use super::database_type::DatabaseType;
+use super::mysql_writer::MySqlItemWriter;
+use super::postgres_writer::PostgresItemWriter;
+use super::sqlite_writer::SqliteItemWriter;
+
+/// Unified builder for creating RDBC item writers for any supported database.
+///
+/// # Type Parameters
+///
+/// * `O` - The item type to write
+///
+/// # Examples
+///
+/// ## SQLite
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::SqlitePool;
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Serialize)]
+/// struct Task { id: i32, title: String, done: bool }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = SqlitePool::connect("sqlite::memory:").await?;
+///
+/// let writer = RdbcItemWriterBuilder::<Task>::new()
+///     .sqlite(&pool)
+///     .table("tasks")
+///     .column("id", |t: &Task| t.id.into())
+///     .column("title", |t: &Task| t.title.as_str().into())
+///     .column("done", |t: &Task| t.done.into())
+///     .build_sqlite();
+/// # Ok(())
+/// # }
+/// ```
+///
+/// ## PostgreSQL
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::PgPool;
+/// use serde::Serialize;
+///
+/// #[derive(Clone, Serialize)]
+/// struct User { id: i32, name: String }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+///
+/// let writer = RdbcItemWriterBuilder::<User>::new()
+///     .postgres(&pool)
+///     .table("users")
+///     .column("id", |u: &User| u.id.into())
+///     .column("name", |u: &User| u.name.as_str().into())
+///     .build_postgres();
+/// # Ok(())
+/// # }
+/// ```
+pub struct RdbcItemWriterBuilder<O> {
+    postgres_pool: Option<sqlx::Pool<Postgres>>,
+    mysql_pool: Option<sqlx::Pool<MySql>>,
+    sqlite_pool: Option<sqlx::Pool<Sqlite>>,
+    table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+    db_type: Option<DatabaseType>,
+}
+
+impl<O: 'static> RdbcItemWriterBuilder<O> {
+    /// Creates a new writer builder with default configuration.
+    pub fn new() -> Self {
+        Self {
+            postgres_pool: None,
+            mysql_pool: None,
+            sqlite_pool: None,
+            table: None,
+            column_bindings: Vec::new(),
+            db_type: None,
+        }
+    }
+
+    /// Sets the PostgreSQL connection pool.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// # use sqlx::PgPool;
+    /// # use serde::Serialize;
+    /// # #[derive(Clone, Serialize)] struct User { id: i32 }
+    /// # async fn ex() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+    /// let builder = RdbcItemWriterBuilder::<User>::new().postgres(&pool);
+    /// # Ok(()) }
+    /// ```
+    pub fn postgres(mut self, pool: &Pool<Postgres>) -> Self {
+        self.postgres_pool = Some(pool.clone());
+        self.db_type = Some(DatabaseType::Postgres);
+        self
+    }
+
+    /// Sets the MySQL connection pool.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// # use sqlx::MySqlPool;
+    /// # use serde::Serialize;
+    /// # #[derive(Clone, Serialize)] struct Product { id: i32 }
+    /// # async fn ex() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
+    /// let builder = RdbcItemWriterBuilder::<Product>::new().mysql(&pool);
+    /// # Ok(()) }
+    /// ```
+    pub fn mysql(mut self, pool: &Pool<MySql>) -> Self {
+        self.mysql_pool = Some(pool.clone());
+        self.db_type = Some(DatabaseType::MySql);
+        self
+    }
+
+    /// Sets the SQLite connection pool.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// # use sqlx::SqlitePool;
+    /// # use serde::Serialize;
+    /// # #[derive(Clone, Serialize)] struct Task { id: i32 }
+    /// # async fn ex() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = SqlitePool::connect("sqlite::memory:").await?;
+    /// let builder = RdbcItemWriterBuilder::<Task>::new().sqlite(&pool);
+    /// # Ok(()) }
+    /// ```
+    pub fn sqlite(mut self, pool: &Pool<Sqlite>) -> Self {
+        self.sqlite_pool = Some(pool.clone());
+        self.db_type = Some(DatabaseType::Sqlite);
+        self
+    }
+
+    /// Sets the target table name.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// # use serde::Serialize;
+    /// # #[derive(Clone, Serialize)] struct Task { id: i32 }
+    /// let builder = RdbcItemWriterBuilder::<Task>::new().table("tasks");
+    /// ```
+    pub fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
+        self
+    }
+
+    /// Adds a column mapping: the extractor closure maps an item to a [`ColumnValue`].
+    ///
+    /// Column order in the generated `INSERT` matches the order of `.column()` calls.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+    /// # use serde::Serialize;
+    /// # #[derive(Clone, Serialize)] struct Task { id: i32, title: String, score: Option<f64> }
+    /// let builder = RdbcItemWriterBuilder::<Task>::new()
+    ///     .table("tasks")
+    ///     .column("id", |t: &Task| t.id.into())
+    ///     .column("title", |t: &Task| t.title.as_str().into())
+    ///     .column("score", |t: &Task| t.score.into());
+    /// ```
+    pub fn column(mut self, name: &str, extractor: impl Fn(&O) -> ColumnValue + 'static) -> Self {
+        self.column_bindings.push((name.to_string(), Box::new(extractor)));
+        self
+    }
+
+    /// Builds a PostgreSQL writer.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic — misconfiguration surfaces as `BatchError` on first `.write()` call.
+    pub fn build_postgres(self) -> PostgresItemWriter<O> {
+        let mut writer = PostgresItemWriter::new();
+        if let Some(pool) = self.postgres_pool {
+            writer = writer.pool(&pool);
+        }
+        if let Some(table) = self.table {
+            writer = writer.table(&table);
+        }
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
+        }
+        writer
+    }
+
+    /// Builds a MySQL writer.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic — misconfiguration surfaces as `BatchError` on first `.write()` call.
+    pub fn build_mysql(self) -> MySqlItemWriter<O> {
+        let mut writer = MySqlItemWriter::new();
+        if let Some(pool) = self.mysql_pool {
+            writer = writer.pool(&pool);
+        }
+        if let Some(table) = self.table {
+            writer = writer.table(&table);
+        }
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
+        }
+        writer
+    }
+
+    /// Builds a SQLite writer.
+    ///
+    /// # Panics
+    ///
+    /// Does not panic — misconfiguration surfaces as `BatchError` on first `.write()` call.
+    pub fn build_sqlite(self) -> SqliteItemWriter<O> {
+        let mut writer = SqliteItemWriter::new();
+        if let Some(pool) = self.sqlite_pool {
+            writer = writer.pool(&pool);
+        }
+        if let Some(table) = self.table {
+            writer = writer.table(&table);
+        }
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
+        }
+        writer
+    }
+}
+
+impl<O: 'static> Default for RdbcItemWriterBuilder<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::BatchError;
+    use crate::item::rdbc::ColumnValue;
+
+    #[test]
+    fn should_transfer_table_to_postgres_writer() {
+        let writer = RdbcItemWriterBuilder::<String>::new()
+            .table("users")
+            .build_postgres();
+        assert_eq!(writer.table.as_deref(), Some("users"));
+    }
+
+    #[test]
+    fn should_accumulate_column_bindings_in_order() {
+        let writer = RdbcItemWriterBuilder::<String>::new()
+            .column("id", |_| ColumnValue::Int(0))
+            .column("name", |_| ColumnValue::Null)
+            .build_postgres();
+        let names: Vec<&str> = writer.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+        assert_eq!(names, vec!["id", "name"]);
+    }
+
+    #[test]
+    fn should_transfer_table_and_columns_to_mysql_writer() {
+        let writer = RdbcItemWriterBuilder::<String>::new()
+            .table("orders")
+            .column("id", |_| ColumnValue::Int(0))
+            .column("total", |_| ColumnValue::Float(0.0))
+            .build_mysql();
+        assert_eq!(writer.table.as_deref(), Some("orders"));
+        assert_eq!(writer.column_bindings.len(), 2);
+    }
+
+    #[test]
+    fn should_return_error_for_missing_pool_on_write() {
+        let writer = RdbcItemWriterBuilder::<String>::new()
+            .table("t")
+            .column("v", |s: &String| s.as_str().into())
+            .build_sqlite();
+        let result = writer.write(&["x".to_string()]);
+        match result.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_pass_pool_to_sqlite_writer() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let writer = RdbcItemWriterBuilder::<String>::new()
+            .sqlite(&pool)
+            .table("t")
+            .column("v", |s: &String| s.as_str().into())
+            .build_sqlite();
+        assert!(writer.pool.is_some(), "pool should be forwarded");
+    }
+
+    #[test]
+    fn should_create_via_default() {
+        let _b = RdbcItemWriterBuilder::<String>::default();
+    }
+}
+```
+
+- [ ] **Step 2: Run builder tests**
+
+```bash
+cargo test --features rdbc-sqlite unified_writer_builder 2>&1 | tail -15
+```
+
+Expected: `test result: ok. 6 passed`
+
+- [ ] **Step 3: Remove `DatabaseItemBinder` from `mod.rs`**
+
+In `src/item/rdbc/mod.rs`:
+
+1. Delete the `DatabaseItemBinder` trait definition (lines containing `pub trait DatabaseItemBinder` through its closing `}`)
+2. Delete the `use sqlx::{Database, query_builder::Separated};` import at the top (it was only needed for the trait)
+
+The final `mod.rs` should look like:
+
+```rust
+/// Fluent SQL SELECT builder for RDBC item readers.
+mod select_builder;
+
+/// Common utilities for database item writers.
+mod writer_common;
+
+/// Common utilities for database item readers.
+mod reader_common;
+
+/// Database type enumeration.
+mod database_type;
+
+/// Unified reader builder for all database types.
+mod unified_reader_builder;
+
+/// Unified writer builder for all database types.
+mod unified_writer_builder;
+
+/// Type-erased column value for item writers.
+mod column_value;
+
+/// PostgreSQL-specific reader implementation.
+pub mod postgres_reader;
+
+/// MySQL-specific reader implementation.
+pub mod mysql_reader;
+
+/// SQLite-specific reader implementation.
+pub mod sqlite_reader;
+
+/// PostgreSQL-specific writer implementation.
+pub mod postgres_writer;
+
+/// MySQL-specific writer implementation.
+pub mod mysql_writer;
+
+/// SQLite-specific writer implementation.
+pub mod sqlite_writer;
+
+// Re-export database-specific reader and writer types (for direct usage)
+pub use mysql_reader::MySqlRdbcItemReader;
+pub use mysql_writer::MySqlItemWriter;
+pub use postgres_reader::PostgresRdbcItemReader;
+pub use postgres_writer::PostgresItemWriter;
+pub use sqlite_reader::SqliteRdbcItemReader;
+pub use sqlite_writer::SqliteItemWriter;
+
+// Re-export unified builder types (recommended API)
+pub use column_value::ColumnValue;
+pub use database_type::DatabaseType;
+pub use select_builder::SelectBuilder;
+pub use unified_reader_builder::RdbcItemReaderBuilder;
+pub use unified_writer_builder::RdbcItemWriterBuilder;
+```
+
+- [ ] **Step 4: Run all rdbc unit tests to confirm no regressions**
+
+```bash
+cargo test --features rdbc-sqlite,rdbc-postgres,rdbc-mysql 2>&1 | tail -20
+```
+
+Expected: all pass, zero compile errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/rdbc/unified_writer_builder.rs src/item/rdbc/mod.rs
+git commit -m "feat(rdbc): add .column() to RdbcItemWriterBuilder; remove DatabaseItemBinder"
+```
+
+---
+
+## Task 7: Update test helpers — remove binder structs, keep `Car`
+
+**Files:**
+- Modify: `tests/helpers/sqlite_helpers.rs`
+- Modify: `tests/helpers/postgres_helpers.rs`
+- Modify: `tests/helpers/mysql_helpers.rs`
+
+- [ ] **Step 1: Update `tests/helpers/sqlite_helpers.rs`**
+
+Remove `SqliteCarItemBinder` struct and its `DatabaseItemBinder` impl. Remove the `use spring_batch_rs::item::rdbc::DatabaseItemBinder;` and `use sqlx::{..., query_builder::Separated};` imports (keep `FromRow`). Keep `Car`, `CREATE_CARS_TABLE_SQL`, `SELECT_ALL_CARS_SQL`, and the `test_car_creation` test.
+
+Replace the file with:
+
+```rust
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Car domain model for database operations.
+#[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]
+pub struct Car {
+    pub year: i16,
+    pub make: String,
+    pub model: String,
+    pub description: String,
+}
+
+impl Car {
+    /// Creates a new Car instance.
+    pub fn new(year: i16, make: String, model: String, description: String) -> Self {
+        Self { year, make, model, description }
+    }
+}
+
+/// SQL statement to create the cars table in SQLite.
+#[allow(dead_code)]
+pub const CREATE_CARS_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS cars (
+        year INTEGER NOT NULL,
+        make VARCHAR(25) NOT NULL,
+        model VARCHAR(25) NOT NULL,
+        description VARCHAR(25) NOT NULL
+    );";
+
+/// SQL statement to select all cars from the table.
+#[allow(dead_code)]
+pub const SELECT_ALL_CARS_SQL: &str = "SELECT year, make, model, description FROM cars";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_car_creation() {
+        let car = Car::new(
+            1967,
+            "Ford".to_string(),
+            "Mustang fastback 1967".to_string(),
+            "American car".to_string(),
+        );
+        assert_eq!(car.year, 1967);
+        assert_eq!(car.make, "Ford");
+        assert_eq!(car.model, "Mustang fastback 1967");
+        assert_eq!(car.description, "American car");
+    }
+}
+```
+
+- [ ] **Step 2: Update `tests/helpers/postgres_helpers.rs`**
+
+Same change — remove `PostgresCarItemBinder` and related imports, keep `Car`, SQL constants, test.
+
+```rust
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Car domain model for database operations.
+#[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]
+pub struct Car {
+    pub year: i16,
+    pub make: String,
+    pub model: String,
+    pub description: String,
+}
+
+impl Car {
+    /// Creates a new Car instance.
+    pub fn new(year: i16, make: String, model: String, description: String) -> Self {
+        Self { year, make, model, description }
+    }
+}
+
+/// SQL statement to create the cars table in PostgreSQL.
+#[allow(dead_code)]
+pub const CREATE_CARS_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS cars (
+        year SMALLINT NOT NULL,
+        make TEXT NOT NULL,
+        model TEXT NOT NULL,
+        description TEXT NOT NULL
+    );";
+
+/// SQL statement to select all cars from the table.
+#[allow(dead_code)]
+pub const SELECT_ALL_CARS_SQL: &str = "SELECT year, make, model, description FROM cars";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_car_creation() {
+        let car = Car::new(
+            1948,
+            "Porsche".to_string(),
+            "356".to_string(),
+            "Luxury sports car".to_string(),
+        );
+        assert_eq!(car.year, 1948);
+        assert_eq!(car.make, "Porsche");
+        assert_eq!(car.model, "356");
+        assert_eq!(car.description, "Luxury sports car");
+    }
+}
+```
+
+- [ ] **Step 3: Update `tests/helpers/mysql_helpers.rs`**
+
+```rust
+use serde::{Deserialize, Serialize};
+use sqlx::FromRow;
+
+/// Car domain model for database operations.
+#[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]
+pub struct Car {
+    pub year: i16,
+    pub make: String,
+    pub model: String,
+    pub description: String,
+}
+
+impl Car {
+    /// Creates a new Car instance.
+    pub fn new(year: i16, make: String, model: String, description: String) -> Self {
+        Self { year, make, model, description }
+    }
+}
+
+/// SQL statement to create the cars table in MySQL.
+#[allow(dead_code)]
+pub const CREATE_CARS_TABLE_SQL: &str = "CREATE TABLE IF NOT EXISTS cars (
+        year SMALLINT NOT NULL,
+        make VARCHAR(25) NOT NULL,
+        model VARCHAR(25) NOT NULL,
+        description VARCHAR(25) NOT NULL
+    );";
+
+/// SQL statement to select all cars from the table.
+#[allow(dead_code)]
+pub const SELECT_ALL_CARS_SQL: &str = "SELECT year, make, model, description FROM cars";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_car_creation() {
+        let car = Car::new(
+            2021,
+            "Mazda".to_string(),
+            "CX-30".to_string(),
+            "SUV Compact".to_string(),
+        );
+        assert_eq!(car.year, 2021);
+        assert_eq!(car.make, "Mazda");
+        assert_eq!(car.model, "CX-30");
+        assert_eq!(car.description, "SUV Compact");
+    }
+}
+```
+
+- [ ] **Step 4: Verify helpers compile**
+
+```bash
+cargo test --features rdbc-sqlite helpers 2>&1 | tail -10
+```
+
+Expected: `test result: ok. 1 passed` (just `test_car_creation`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/helpers/sqlite_helpers.rs tests/helpers/postgres_helpers.rs tests/helpers/mysql_helpers.rs
+git commit -m "refactor(tests): remove CarItemBinder structs from test helpers"
+```
+
+---
+
+## Task 8: Update integration tests — rewrite writer tests with `.column()`, add nullable tests
+
+**Files:**
+- Modify: `tests/rdbc_sqlite.rs`
+- Modify: `tests/rdbc_postgres.rs`
+- Modify: `tests/rdbc_mysql.rs`
+
+Each of these files has one writer integration test that creates a binder, calls `.sqlite_binder()`/`.postgres_binder()`/`.mysql_binder()`, and uses `.add_column()`. Replace those calls with `.column()` chains.
+
+- [ ] **Step 1: Update the SQLite writer integration test**
+
+In `tests/rdbc_sqlite.rs`, find the import line:
+```rust
+sqlite_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL, SqliteCarItemBinder},
+```
+Change it to:
+```rust
+sqlite_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
+```
+
+Find the writer test body (the function that creates `SqliteCarItemBinder` and calls `.sqlite_binder()`). The old code looks like:
+```rust
+let item_binder = SqliteCarItemBinder;
+let writer = RdbcItemWriterBuilder::<Car>::new()
+    .sqlite(&pool)
+    .table("cars")
+    .add_column("year")
+    .add_column("make")
+    .add_column("model")
+    .add_column("description")
+    .sqlite_binder(&item_binder)
+    .build_sqlite();
+```
+
+Replace with:
+```rust
+let writer = RdbcItemWriterBuilder::<Car>::new()
+    .sqlite(&pool)
+    .table("cars")
+    .column("year", |c: &Car| (c.year as i32).into())
+    .column("make", |c: &Car| c.make.as_str().into())
+    .column("model", |c: &Car| c.model.as_str().into())
+    .column("description", |c: &Car| c.description.as_str().into())
+    .build_sqlite();
+```
+
+Also remove the `use spring_batch_rs::item::rdbc::DatabaseItemBinder;` import if present (check the top of the file).
+
+- [ ] **Step 2: Add the nullable SQLite integration test**
+
+At the end of `tests/rdbc_sqlite.rs`, add this test function (replace `my_test_fn` with an appropriate `#[tokio::test]` annotation matching the existing tests in the file):
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn should_write_null_optional_column_to_sqlite() -> Result<(), testcontainers::TestcontainersError> {
+    use spring_batch_rs::item::rdbc::{ColumnValue, RdbcItemWriterBuilder};
+
+    // Uses in-memory SQLite — no container needed
+    let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+    sqlx::query("CREATE TABLE notes (id INTEGER NOT NULL, body TEXT)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    #[derive(Clone, serde::Serialize)]
+    struct Note { id: i32, body: Option<String> }
+
+    let writer = RdbcItemWriterBuilder::<Note>::new()
+        .sqlite(&pool)
+        .table("notes")
+        .column("id", |n: &Note| n.id.into())
+        .column("body", |n: &Note| n.body.clone().into())
+        .build_sqlite();
+
+    use spring_batch_rs::core::item::ItemWriter;
+    writer
+        .write(&[Note { id: 1, body: None }, Note { id: 2, body: Some("hello".to_string()) }])
+        .unwrap();
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(body.is_none(), "id=1 body should be NULL");
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 2")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(body.as_deref(), Some("hello"), "id=2 body should be 'hello'");
+
+    Ok(())
+}
+```
+
+- [ ] **Step 3: Update the Postgres writer integration test**
+
+In `tests/rdbc_postgres.rs`, change the import:
+```rust
+postgres_helpers::{CREATE_CARS_TABLE_SQL, Car, PostgresCarItemBinder, SELECT_ALL_CARS_SQL},
+```
+to:
+```rust
+postgres_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
+```
+
+Replace the writer construction block (old code has `PostgresCarItemBinder`, `.postgres_binder()`, and `.add_column()`):
+```rust
+let writer = RdbcItemWriterBuilder::<Car>::new()
+    .postgres(&pool)
+    .table("cars")
+    .column("year", |c: &Car| (c.year as i32).into())
+    .column("make", |c: &Car| c.make.as_str().into())
+    .column("model", |c: &Car| c.model.as_str().into())
+    .column("description", |c: &Car| c.description.as_str().into())
+    .build_postgres();
+```
+
+Add nullable integration test at the end of the file (uses the same testcontainers Postgres container pattern as the existing tests — copy the container setup from the existing write test):
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn should_write_null_optional_column_to_postgres() -> Result<(), testcontainers::TestcontainersError> {
+    use spring_batch_rs::item::rdbc::{ColumnValue, RdbcItemWriterBuilder};
+    use testcontainers_modules::{postgres, testcontainers::runners::AsyncRunner};
+
+    let container = postgres::Postgres::default().start().await?;
+    let host_ip = container.get_host().await?;
+    let host_port = container.get_host_port_ipv4(5432).await?;
+    let url = format!("postgres://postgres:postgres@{}:{}", host_ip, host_port);
+    let pool = sqlx::PgPool::connect(&url).await.unwrap();
+
+    sqlx::query("CREATE TABLE notes (id INT NOT NULL, body TEXT)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    #[derive(Clone, serde::Serialize)]
+    struct Note { id: i32, body: Option<String> }
+
+    let writer = RdbcItemWriterBuilder::<Note>::new()
+        .postgres(&pool)
+        .table("notes")
+        .column("id", |n: &Note| n.id.into())
+        .column("body", |n: &Note| n.body.clone().into())
+        .build_postgres();
+
+    use spring_batch_rs::core::item::ItemWriter;
+    writer
+        .write(&[Note { id: 1, body: None }, Note { id: 2, body: Some("pg".to_string()) }])
+        .unwrap();
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(body.is_none(), "id=1 body should be NULL");
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 2")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(body.as_deref(), Some("pg"));
+
+    Ok(())
+}
+```
+
+- [ ] **Step 4: Update the MySQL writer integration test**
+
+In `tests/rdbc_mysql.rs`, change the import:
+```rust
+mysql_helpers::{CREATE_CARS_TABLE_SQL, Car, MySqlCarItemBinder, SELECT_ALL_CARS_SQL},
+```
+to:
+```rust
+mysql_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
+```
+
+Replace the writer construction block:
+```rust
+let writer = RdbcItemWriterBuilder::<Car>::new()
+    .mysql(&pool)
+    .table("cars")
+    .column("year", |c: &Car| (c.year as i32).into())
+    .column("make", |c: &Car| c.make.as_str().into())
+    .column("model", |c: &Car| c.model.as_str().into())
+    .column("description", |c: &Car| c.description.as_str().into())
+    .build_mysql();
+```
+
+Add nullable integration test (uses the same testcontainers MySQL container pattern as existing tests):
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn should_write_null_optional_column_to_mysql() -> Result<(), testcontainers::TestcontainersError> {
+    use spring_batch_rs::item::rdbc::{ColumnValue, RdbcItemWriterBuilder};
+    use testcontainers_modules::{mysql, testcontainers::runners::AsyncRunner};
+    let container = mysql::Mysql::default().start().await?;
+    let host_ip = container.get_host().await?;
+    let port = container.get_host_port_ipv4(3306).await?;
+    let url = format!("mysql://{}:{}/test", host_ip, port);
+    let pool = sqlx::MySqlPool::connect(&url).await.unwrap();
+
+    sqlx::query("CREATE TABLE notes (id INT NOT NULL, body VARCHAR(255))")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    #[derive(Clone, serde::Serialize)]
+    struct Note { id: i32, body: Option<String> }
+
+    let writer = RdbcItemWriterBuilder::<Note>::new()
+        .mysql(&pool)
+        .table("notes")
+        .column("id", |n: &Note| n.id.into())
+        .column("body", |n: &Note| n.body.clone().into())
+        .build_mysql();
+
+    use spring_batch_rs::core::item::ItemWriter;
+    writer
+        .write(&[Note { id: 1, body: None }, Note { id: 2, body: Some("mysql".to_string()) }])
+        .unwrap();
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 1")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert!(body.is_none(), "id=1 body should be NULL");
+
+    let (body,): (Option<String>,) = sqlx::query_as("SELECT body FROM notes WHERE id = 2")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+    assert_eq!(body.as_deref(), Some("mysql"));
+
+    Ok(())
+}
+```
+
+- [ ] **Step 5: Run SQLite integration tests (fast, no Docker)**
+
+```bash
+cargo test --test rdbc_sqlite --features rdbc-sqlite 2>&1 | tail -15
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/rdbc_sqlite.rs tests/rdbc_postgres.rs tests/rdbc_mysql.rs
+git commit -m "test(rdbc): rewrite writer integration tests with .column() API; add nullable tests"
+```
+
+---
+
+## Task 9: Update examples — replace binder structs with `.column()` chains
+
+**Files:**
+- Modify: `examples/database_processing.rs`
+- Modify: `examples/benchmark_csv_postgres_xml.rs`
+
+- [ ] **Step 1: Update `examples/database_processing.rs`**
+
+Remove the `use spring_batch_rs::item::rdbc::DatabaseItemBinder;` import and the `use sqlx::{..., query_builder::Separated};` import (keep other imports).
+
+Delete the `UserBinder` struct and its `DatabaseItemBinder<User, Sqlite>` impl entirely.
+
+Delete the `ProductBinder` struct and its `DatabaseItemBinder<Product, Sqlite>` impl entirely.
+
+Find the User writer construction (currently uses `sqlite_binder(&binder)` and four `.add_column()` calls) and replace with:
+
+```rust
+// 1. Build writer — maps User fields to SQLite columns
+let writer = RdbcItemWriterBuilder::<User>::new()
+    .sqlite(&pool)
+    .table("users")
+    .column("id", |u: &User| u.id.into())
+    .column("name", |u: &User| u.name.as_str().into())
+    .column("email", |u: &User| u.email.as_str().into())
+    .column("active", |u: &User| u.active.into())
+    .build_sqlite();
+```
+
+Find the Product writer construction and replace with:
+
+```rust
+// 1. Build writer — maps Product fields to SQLite columns
+let writer = RdbcItemWriterBuilder::<Product>::new()
+    .sqlite(&pool)
+    .table("products")
+    .column("id", |p: &Product| p.id.into())
+    .column("name", |p: &Product| p.name.as_str().into())
+    .column("price", |p: &Product| p.price.into())
+    .column("stock", |p: &Product| p.stock.into())
+    .build_sqlite();
+```
+
+Also remove `use spring_batch_rs::item::rdbc::ColumnValue` — it's not needed since `Into<ColumnValue>` is called via `.into()` and the compiler infers the type from the return type of the closure (which must be `ColumnValue`). No explicit import needed unless used directly.
+
+Actually — the closures return `ColumnValue` so `ColumnValue` must be in scope. Add the import:
+```rust
+use spring_batch_rs::item::rdbc::{RdbcItemReaderBuilder, RdbcItemWriterBuilder};
+```
+(The existing import likely already has `RdbcItemWriterBuilder` — just remove `DatabaseItemBinder` from it.)
+
+- [ ] **Step 2: Update `examples/benchmark_csv_postgres_xml.rs`**
+
+Remove `use spring_batch_rs::item::rdbc::DatabaseItemBinder;` from the import.
+
+Delete the `TransactionBinder` struct and its `DatabaseItemBinder<Transaction, Postgres>` impl entirely.
+
+Delete the `TransactionImportBinder` struct and its `DatabaseItemBinder<Transaction, Postgres>` impl entirely.
+
+Find the first Transaction writer construction (step 2, writes to `transactions` table — currently has `TransactionBinder`, `.postgres_binder(&binder)`, and eight `.add_column()` calls). Replace with:
+
+```rust
+let writer = RdbcItemWriterBuilder::<Transaction>::new()
+    .postgres(&pg_pool)
+    .table("transactions")
+    .column("transaction_id", |t: &Transaction| t.transaction_id.as_str().into())
+    .column("amount", |t: &Transaction| t.amount.into())
+    .column("currency", |t: &Transaction| t.currency.as_str().into())
+    .column("timestamp", |t: &Transaction| t.timestamp.as_str().into())
+    .column("account_from", |t: &Transaction| t.account_from.as_str().into())
+    .column("account_to", |t: &Transaction| t.account_to.as_str().into())
+    .column("status", |t: &Transaction| t.status.as_str().into())
+    .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+    .build_postgres();
+```
+
+Find the second Transaction writer construction (step 3, writes to `transactions_import` table — currently has `TransactionImportBinder`). Replace with:
+
+```rust
+let writer = RdbcItemWriterBuilder::<Transaction>::new()
+    .postgres(&pg_pool)
+    .table("transactions_import")
+    .column("transaction_id", |t: &Transaction| t.transaction_id.as_str().into())
+    .column("amount", |t: &Transaction| t.amount.into())
+    .column("currency", |t: &Transaction| t.currency.as_str().into())
+    .column("timestamp", |t: &Transaction| t.timestamp.as_str().into())
+    .column("account_from", |t: &Transaction| t.account_from.as_str().into())
+    .column("account_to", |t: &Transaction| t.account_to.as_str().into())
+    .column("status", |t: &Transaction| t.status.as_str().into())
+    .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+    .build_postgres();
+```
+
+- [ ] **Step 3: Verify examples compile**
+
+```bash
+cargo build --example database_processing --features rdbc-sqlite,logger 2>&1 | tail -10
+cargo build --example benchmark_csv_postgres_xml --features rdbc-postgres,csv,xml,logger 2>&1 | tail -10
+```
+
+Expected: `Finished` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add examples/database_processing.rs examples/benchmark_csv_postgres_xml.rs
+git commit -m "feat(examples): replace DatabaseItemBinder with .column() API"
+```
+
+---
+
+## Task 10: Final compile and test verification
+
+- [ ] **Step 1: Run full unit test suite**
+
+```bash
+cargo test --features rdbc-sqlite,rdbc-postgres,rdbc-mysql 2>&1 | tail -20
+```
+
+Expected: all unit tests pass, no compile errors.
+
+- [ ] **Step 2: Verify rustdoc builds clean**
+
+```bash
+cargo doc --no-deps --features rdbc-sqlite,rdbc-postgres,rdbc-mysql 2>&1 | grep -E "warning|error" | head -20
+```
+
+Expected: no warnings, no errors.
+
+- [ ] **Step 3: Run clippy**
+
+```bash
+cargo clippy --features rdbc-sqlite,rdbc-postgres,rdbc-mysql -- -D warnings 2>&1 | tail -20
+```
+
+Expected: no warnings.
+
+- [ ] **Step 4: Run rustfmt check**
+
+```bash
+cargo fmt --all -- --check 2>&1 | tail -10
+```
+
+If any formatting issues: run `cargo fmt --all` then re-check.
+
+- [ ] **Step 5: Commit format fixes if needed**
+
+```bash
+git add -p
+git commit -m "style: rustfmt formatting"
+```

--- a/docs/superpowers/plans/2026-05-15-rdbc-select-builder.md
+++ b/docs/superpowers/plans/2026-05-15-rdbc-select-builder.md
@@ -1,0 +1,1432 @@
+# RDBC SelectBuilder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a fluent `SelectBuilder<I>` that generates SQL SELECT strings as an alternative to raw `.query()` strings on `RdbcItemReaderBuilder`.
+
+**Architecture:** A new database-agnostic `SelectBuilder<I>` struct generates the base SQL string from typed conditions. `RdbcItemReaderBuilder` gains a `.select()` method that extracts the SQL and propagates keyset config. Readers switch from `&'a str` to owned `String` to support the built-query path without lifetime issues.
+
+**Tech Stack:** Rust 2021, sqlx, cargo test `--all-features`
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `src/item/rdbc/select_builder.rs` | **Create** — full `SelectBuilder<I>` implementation |
+| `src/item/rdbc/postgres_reader.rs` | **Modify** — `query: &'a str` → `query: String`, remove `'a` lifetime |
+| `src/item/rdbc/mysql_reader.rs` | **Modify** — same as postgres_reader |
+| `src/item/rdbc/sqlite_reader.rs` | **Modify** — same as postgres_reader |
+| `src/item/rdbc/unified_reader_builder.rs` | **Modify** — add `QuerySource`, `.select()`, update build methods |
+| `src/item/rdbc/mod.rs` | **Modify** — declare and export `select_builder` module |
+
+---
+
+## Task 1: Create `select_builder.rs` with internal types and `build_sql`
+
+**Files:**
+- Create: `src/item/rdbc/select_builder.rs`
+
+> Note: `ConditionValue`, `WhereClause`, and `OrderClause` are `pub(crate)` — users interact only via builder methods and `impl Into<ConditionValue>` conversions.
+
+- [ ] **Step 1.1: Write the failing tests first**
+
+Add this entire file to `src/item/rdbc/select_builder.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    #[test]
+    fn should_generate_select_star_when_no_columns_given() {
+        let sql = SelectBuilder::<Dummy>::from("users").build_sql();
+        assert_eq!(sql, "SELECT * FROM users", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_column_list() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .columns(&["id", "amount", "status"])
+            .build_sql();
+        assert_eq!(sql, "SELECT id, amount, status FROM orders", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_string() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("status", "ACTIVE")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE status = 'ACTIVE'", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_integer() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("age", 30i32)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE age = 30", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_bool() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("active", true)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE active = true", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_escape_single_quotes_in_string_values() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("name", "O'Brien")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE name = 'O''Brien'", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_not_eq() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_not_eq("role", "ADMIN")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE role != 'ADMIN'", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_gt() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gt("amount", 100i64)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM orders WHERE amount > 100", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_gte() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gte("score", 0.5f64)
+            .build_sql();
+        assert!(sql.starts_with("SELECT * FROM orders WHERE score >= "), "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_lt() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lt("stock", 10i32)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM items WHERE stock < 10", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_lte() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lte("rank", 100i32)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM items WHERE rank <= 100", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_like() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_like("email", "%@corp.com")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE email LIKE '%@corp.com'", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_is_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_null("deleted_at")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE deleted_at IS NULL", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_where_is_not_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_not_null("confirmed_at")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users WHERE confirmed_at IS NOT NULL", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_join_multiple_conditions_with_and() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("status", "ACTIVE")
+            .where_is_null("deleted_at")
+            .where_gt("age", 18i32)
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT * FROM users WHERE status = 'ACTIVE' AND deleted_at IS NULL AND age > 18",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_asc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("created_at")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users ORDER BY created_at ASC", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_order_by_desc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_desc("score")
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM users ORDER BY score DESC", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_multiple_order_by_clauses() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("last_name")
+            .order_by_desc("score")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT * FROM users ORDER BY last_name ASC, score DESC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_full_select_with_columns_conditions_and_order() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .columns(&["id", "name", "email"])
+            .where_eq("status", "ACTIVE")
+            .where_is_null("deleted_at")
+            .order_by_asc("id")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT id, name, email FROM users WHERE status = 'ACTIVE' AND deleted_at IS NULL ORDER BY id ASC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_set_keyset_column_and_key_fn_on_order_by_keyset() {
+        let builder = SelectBuilder::<Dummy>::from("users")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string());
+        assert_eq!(builder.keyset_column.as_deref(), Some("id"), "keyset column should be set");
+        assert!(builder.keyset_key_fn.is_some(), "keyset key fn should be set");
+    }
+
+    #[test]
+    fn should_replace_previous_order_by_on_keyset() {
+        let builder = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("name")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string());
+        let sql = builder.build_sql();
+        assert_eq!(sql, "SELECT * FROM users ORDER BY id ASC", "previous order_by should be replaced: {sql}");
+    }
+
+    #[test]
+    fn should_generate_order_by_asc_in_sql_for_keyset() {
+        let sql = SelectBuilder::<Dummy>::from("events")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string())
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM events ORDER BY id ASC", "unexpected: {sql}");
+    }
+}
+```
+
+- [ ] **Step 1.2: Run the tests — expect compilation failure**
+
+```bash
+cargo test --features rdbc-sqlite -p sbrs-lib 2>&1 | head -20
+```
+
+Expected: compile error — `select_builder` module not found or `SelectBuilder` not defined.
+
+- [ ] **Step 1.3: Write the full implementation**
+
+Replace the contents of `src/item/rdbc/select_builder.rs` with:
+
+```rust
+//! Fluent SQL SELECT builder for RDBC item readers.
+//!
+//! Use [`SelectBuilder`] to construct a `SELECT` query without writing raw SQL.
+//! Pass the result to [`RdbcItemReaderBuilder::select`] instead of `.query()`.
+//!
+//! # Examples
+//!
+//! ```
+//! use spring_batch_rs::item::rdbc::SelectBuilder;
+//!
+//! struct Order { id: i64, amount: f64 }
+//!
+//! let sql = SelectBuilder::<Order>::from("orders")
+//!     .columns(&["id", "amount"])
+//!     .where_eq("status", "PENDING")
+//!     .where_gt("amount", 0.0f64)
+//!     .order_by_asc("id")
+//!     .build_sql();
+//!
+//! assert!(sql.starts_with("SELECT id, amount FROM orders WHERE"));
+//! ```
+
+use std::marker::PhantomData;
+
+pub(crate) enum ConditionValue {
+    Integer(i64),
+    Float(f64),
+    Text(String),
+    Bool(bool),
+}
+
+impl ConditionValue {
+    fn to_sql(&self) -> String {
+        match self {
+            ConditionValue::Integer(n) => n.to_string(),
+            ConditionValue::Float(f) => f.to_string(),
+            ConditionValue::Bool(b) => b.to_string(),
+            ConditionValue::Text(s) => format!("'{}'", s.replace('\'', "''")),
+        }
+    }
+}
+
+impl From<i32> for ConditionValue {
+    fn from(v: i32) -> Self {
+        ConditionValue::Integer(i64::from(v))
+    }
+}
+
+impl From<i64> for ConditionValue {
+    fn from(v: i64) -> Self {
+        ConditionValue::Integer(v)
+    }
+}
+
+impl From<f32> for ConditionValue {
+    fn from(v: f32) -> Self {
+        ConditionValue::Float(f64::from(v))
+    }
+}
+
+impl From<f64> for ConditionValue {
+    fn from(v: f64) -> Self {
+        ConditionValue::Float(v)
+    }
+}
+
+impl From<bool> for ConditionValue {
+    fn from(v: bool) -> Self {
+        ConditionValue::Bool(v)
+    }
+}
+
+impl From<&str> for ConditionValue {
+    fn from(v: &str) -> Self {
+        ConditionValue::Text(v.to_string())
+    }
+}
+
+impl From<String> for ConditionValue {
+    fn from(v: String) -> Self {
+        ConditionValue::Text(v)
+    }
+}
+
+pub(crate) enum WhereClause {
+    Eq(String, ConditionValue),
+    NotEq(String, ConditionValue),
+    Gt(String, ConditionValue),
+    Gte(String, ConditionValue),
+    Lt(String, ConditionValue),
+    Lte(String, ConditionValue),
+    Like(String, String),
+    IsNull(String),
+    IsNotNull(String),
+}
+
+impl WhereClause {
+    fn to_sql(&self) -> String {
+        match self {
+            WhereClause::Eq(col, val) => format!("{} = {}", col, val.to_sql()),
+            WhereClause::NotEq(col, val) => format!("{} != {}", col, val.to_sql()),
+            WhereClause::Gt(col, val) => format!("{} > {}", col, val.to_sql()),
+            WhereClause::Gte(col, val) => format!("{} >= {}", col, val.to_sql()),
+            WhereClause::Lt(col, val) => format!("{} < {}", col, val.to_sql()),
+            WhereClause::Lte(col, val) => format!("{} <= {}", col, val.to_sql()),
+            WhereClause::Like(col, pat) => {
+                format!("{} LIKE '{}'", col, pat.replace('\'', "''"))
+            }
+            WhereClause::IsNull(col) => format!("{} IS NULL", col),
+            WhereClause::IsNotNull(col) => format!("{} IS NOT NULL", col),
+        }
+    }
+}
+
+pub(crate) enum OrderClause {
+    Asc(String),
+    Desc(String),
+}
+
+/// Fluent builder for SQL `SELECT` queries used with [`RdbcItemReaderBuilder::select`].
+///
+/// Generic over `I` (the item type) only when [`order_by_keyset`] is used to carry
+/// the cursor extraction closure. In all other cases `I` is inferred from context.
+///
+/// # Examples
+///
+/// ```
+/// use spring_batch_rs::item::rdbc::SelectBuilder;
+///
+/// struct User { id: i64, name: String }
+///
+/// let sql = SelectBuilder::<User>::from("users")
+///     .columns(&["id", "name"])
+///     .where_eq("active", true)
+///     .order_by_keyset("id", |u: &User| u.id.to_string())
+///     .build_sql();
+///
+/// assert_eq!(sql, "SELECT id, name FROM users WHERE active = true ORDER BY id ASC");
+/// ```
+pub struct SelectBuilder<I> {
+    table: String,
+    columns: Vec<String>,
+    conditions: Vec<WhereClause>,
+    order_by: Vec<OrderClause>,
+    pub(crate) keyset_column: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) keyset_key_fn: Option<Box<dyn Fn(&I) -> String>>,
+    _phantom: PhantomData<I>,
+}
+
+impl<I> SelectBuilder<I> {
+    /// Creates a new builder targeting the given table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    /// let builder = SelectBuilder::<Row>::from("users");
+    /// assert_eq!(builder.build_sql(), "SELECT * FROM users");
+    /// ```
+    pub fn from(table: impl Into<String>) -> Self {
+        Self {
+            table: table.into(),
+            columns: Vec::new(),
+            conditions: Vec::new(),
+            order_by: Vec::new(),
+            keyset_column: None,
+            keyset_key_fn: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Sets the columns to select. Omitting this call generates `SELECT *`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    /// let sql = SelectBuilder::<Row>::from("t").columns(&["a", "b"]).build_sql();
+    /// assert_eq!(sql, "SELECT a, b FROM t");
+    /// ```
+    pub fn columns(mut self, cols: &[&str]) -> Self {
+        self.columns = cols.iter().map(|s| (*s).to_string()).collect();
+        self
+    }
+
+    /// Adds a `col = value` condition.
+    pub fn where_eq(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Eq(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col != value` condition.
+    pub fn where_not_eq(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::NotEq(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col > value` condition.
+    pub fn where_gt(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Gt(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col >= value` condition.
+    pub fn where_gte(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Gte(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col < value` condition.
+    pub fn where_lt(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Lt(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col <= value` condition.
+    pub fn where_lte(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Lte(col.to_string(), val.into()));
+        self
+    }
+
+    /// Adds a `col LIKE pattern` condition.
+    pub fn where_like(mut self, col: &str, pat: &str) -> Self {
+        self.conditions
+            .push(WhereClause::Like(col.to_string(), pat.to_string()));
+        self
+    }
+
+    /// Adds a `col IS NULL` condition.
+    pub fn where_is_null(mut self, col: &str) -> Self {
+        self.conditions.push(WhereClause::IsNull(col.to_string()));
+        self
+    }
+
+    /// Adds a `col IS NOT NULL` condition.
+    pub fn where_is_not_null(mut self, col: &str) -> Self {
+        self.conditions
+            .push(WhereClause::IsNotNull(col.to_string()));
+        self
+    }
+
+    /// Adds an `ORDER BY col ASC` clause.
+    pub fn order_by_asc(mut self, col: &str) -> Self {
+        self.order_by.push(OrderClause::Asc(col.to_string()));
+        self
+    }
+
+    /// Adds an `ORDER BY col DESC` clause.
+    pub fn order_by_desc(mut self, col: &str) -> Self {
+        self.order_by.push(OrderClause::Desc(col.to_string()));
+        self
+    }
+
+    /// Configures keyset (cursor) pagination on `col`.
+    ///
+    /// Replaces all previous `order_by_*` calls. Sets `ORDER BY col ASC` and stores
+    /// `key_fn` to extract the cursor value from each item. When passed to
+    /// [`RdbcItemReaderBuilder::select`], keyset pagination is enabled automatically
+    /// without a separate `.with_keyset()` call.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct User { id: i64 }
+    ///
+    /// let sql = SelectBuilder::<User>::from("users")
+    ///     .order_by_keyset("id", |u: &User| u.id.to_string())
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users ORDER BY id ASC");
+    /// ```
+    pub fn order_by_keyset(mut self, col: &str, key_fn: impl Fn(&I) -> String + 'static) -> Self {
+        self.order_by.clear();
+        self.order_by.push(OrderClause::Asc(col.to_string()));
+        self.keyset_column = Some(col.to_string());
+        self.keyset_key_fn = Some(Box::new(key_fn));
+        self
+    }
+
+    /// Generates the base SQL string (without `LIMIT`, `OFFSET`, or keyset `WHERE` clauses).
+    ///
+    /// Those clauses are appended by the reader at execution time.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    /// let sql = SelectBuilder::<Row>::from("items")
+    ///     .columns(&["id", "name"])
+    ///     .where_is_null("deleted_at")
+    ///     .order_by_asc("id")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT id, name FROM items WHERE deleted_at IS NULL ORDER BY id ASC");
+    /// ```
+    pub fn build_sql(&self) -> String {
+        let cols = if self.columns.is_empty() {
+            "*".to_string()
+        } else {
+            self.columns.join(", ")
+        };
+
+        let mut sql = format!("SELECT {} FROM {}", cols, self.table);
+
+        if !self.conditions.is_empty() {
+            let clauses: Vec<String> = self.conditions.iter().map(WhereClause::to_sql).collect();
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+
+        if !self.order_by.is_empty() {
+            let clauses: Vec<String> = self
+                .order_by
+                .iter()
+                .map(|o| match o {
+                    OrderClause::Asc(col) => format!("{} ASC", col),
+                    OrderClause::Desc(col) => format!("{} DESC", col),
+                })
+                .collect();
+            sql.push_str(" ORDER BY ");
+            sql.push_str(&clauses.join(", "));
+        }
+
+        sql
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    #[test]
+    fn should_generate_select_star_when_no_columns_given() {
+        let sql = SelectBuilder::<Dummy>::from("users").build_sql();
+        assert_eq!(sql, "SELECT * FROM users", "unexpected: {sql}");
+    }
+
+    #[test]
+    fn should_generate_column_list() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .columns(&["id", "amount", "status"])
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT id, amount, status FROM orders",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_string() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("status", "ACTIVE")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE status = 'ACTIVE'",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_integer() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("age", 30i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE age = 30",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_bool() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("active", true)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE active = true",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_escape_single_quotes_in_string_values() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("name", "O'Brien")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE name = 'O''Brien'",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_not_eq() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_not_eq("role", "ADMIN")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE role != 'ADMIN'",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_gt() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gt("amount", 100i64)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM orders WHERE amount > 100",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_gte() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gte("score", 0.5f64)
+            .build_sql();
+        assert!(
+            sql.starts_with("SELECT * FROM orders WHERE score >= "),
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_lt() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lt("stock", 10i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM items WHERE stock < 10",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_lte() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lte("rank", 100i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM items WHERE rank <= 100",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_like() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_like("email", "%@corp.com")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE email LIKE '%@corp.com'",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_is_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_null("deleted_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE deleted_at IS NULL",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_is_not_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_not_null("confirmed_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE confirmed_at IS NOT NULL",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_join_multiple_conditions_with_and() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("status", "ACTIVE")
+            .where_is_null("deleted_at")
+            .where_gt("age", 18i32)
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT * FROM users WHERE status = 'ACTIVE' AND deleted_at IS NULL AND age > 18",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_asc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("created_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users ORDER BY created_at ASC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_desc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_desc("score")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users ORDER BY score DESC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_multiple_order_by_clauses() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("last_name")
+            .order_by_desc("score")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT * FROM users ORDER BY last_name ASC, score DESC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_full_select_with_columns_conditions_and_order() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .columns(&["id", "name", "email"])
+            .where_eq("status", "ACTIVE")
+            .where_is_null("deleted_at")
+            .order_by_asc("id")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT id, name, email FROM users WHERE status = 'ACTIVE' AND deleted_at IS NULL ORDER BY id ASC",
+            "unexpected: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_set_keyset_column_and_key_fn_on_order_by_keyset() {
+        let builder = SelectBuilder::<Dummy>::from("users")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string());
+        assert_eq!(
+            builder.keyset_column.as_deref(),
+            Some("id"),
+            "keyset column should be set"
+        );
+        assert!(
+            builder.keyset_key_fn.is_some(),
+            "keyset key fn should be set"
+        );
+    }
+
+    #[test]
+    fn should_replace_previous_order_by_on_keyset() {
+        let builder = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("name")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string());
+        let sql = builder.build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users ORDER BY id ASC",
+            "previous order_by should be replaced: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_asc_in_sql_for_keyset() {
+        let sql = SelectBuilder::<Dummy>::from("events")
+            .order_by_keyset("id", |_: &Dummy| "0".to_string())
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM events ORDER BY id ASC",
+            "unexpected: {sql}"
+        );
+    }
+}
+```
+
+- [ ] **Step 1.4: Declare the module in `mod.rs`**
+
+In `src/item/rdbc/mod.rs`, add before the existing `pub mod postgres_reader;` line:
+
+```rust
+/// Fluent SQL SELECT builder for RDBC item readers.
+pub mod select_builder;
+```
+
+And add to the re-exports at the bottom:
+
+```rust
+pub use select_builder::SelectBuilder;
+```
+
+- [ ] **Step 1.5: Run tests and verify they pass**
+
+```bash
+cargo test select_builder --features rdbc-sqlite -p sbrs-lib 2>&1
+```
+
+Expected: all `select_builder::tests::*` tests PASS, zero warnings.
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add src/item/rdbc/select_builder.rs src/item/rdbc/mod.rs
+git commit -m "feat(rdbc): add SelectBuilder for fluent SQL SELECT generation"
+```
+
+---
+
+## Task 2: Migrate readers from borrowed `&'a str` to owned `String`
+
+The readers currently store `query: &'a str`, which prevents the builder from passing a `String` produced by `SelectBuilder::build_sql()`. Changing to `String` removes the `'a` lifetime from the reader structs entirely.
+
+**Files:**
+- Modify: `src/item/rdbc/postgres_reader.rs`
+- Modify: `src/item/rdbc/mysql_reader.rs`
+- Modify: `src/item/rdbc/sqlite_reader.rs`
+
+- [ ] **Step 2.1: Migrate `postgres_reader.rs`**
+
+Apply the following changes to `src/item/rdbc/postgres_reader.rs`:
+
+**Change 1** — struct definition: remove `'a`, change `query` field type.
+
+Old:
+```rust
+pub struct PostgresRdbcItemReader<'a, I>
+where
+    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
+{
+    pub(crate) pool: Pool<Postgres>,
+    pub(crate) query: &'a str,
+```
+
+New:
+```rust
+pub struct PostgresRdbcItemReader<I>
+where
+    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
+{
+    pub(crate) pool: Pool<Postgres>,
+    pub(crate) query: String,
+```
+
+**Change 2** — `impl` block signature:
+
+Old:
+```rust
+impl<'a, I> PostgresRdbcItemReader<'a, I>
+where
+    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
+```
+
+New:
+```rust
+impl<I> PostgresRdbcItemReader<I>
+where
+    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
+```
+
+**Change 3** — `new()` signature:
+
+Old:
+```rust
+pub fn new(
+    pool: Pool<Postgres>,
+    query: &'a str,
+    page_size: Option<i32>,
+    keyset_column: Option<String>,
+    keyset_key: Option<Box<dyn Fn(&I) -> String>>,
+) -> Self {
+    Self {
+        pool,
+        query,
+```
+
+New:
+```rust
+pub fn new(
+    pool: Pool<Postgres>,
+    query: String,
+    page_size: Option<i32>,
+    keyset_column: Option<String>,
+    keyset_key: Option<Box<dyn Fn(&I) -> String>>,
+) -> Self {
+    Self {
+        pool,
+        query,
+```
+
+**Change 4** — `read_page()`: change `self.query` reference (it's already a `String`, so this works without change since `QueryBuilder::new` accepts `&str` and `String` deref to `&str`). No change needed here.
+
+**Change 5** — `ItemReader` impl signature:
+
+Old:
+```rust
+impl<I> ItemReader<I> for PostgresRdbcItemReader<'_, I>
+```
+
+New:
+```rust
+impl<I> ItemReader<I> for PostgresRdbcItemReader<I>
+```
+
+**Change 6** — update the test `reader_with_keyset` helper:
+
+Old:
+```rust
+fn reader_with_keyset(keyset: bool) -> PostgresRdbcItemReader<'static, Dummy> {
+    ...
+    PostgresRdbcItemReader::new(pool, "SELECT 1", Some(10), col, key)
+```
+
+New:
+```rust
+fn reader_with_keyset(keyset: bool) -> PostgresRdbcItemReader<Dummy> {
+    ...
+    PostgresRdbcItemReader::new(pool, "SELECT 1".to_string(), Some(10), col, key)
+```
+
+- [ ] **Step 2.2: Migrate `mysql_reader.rs`**
+
+Apply the identical set of changes to `src/item/rdbc/mysql_reader.rs` (replace `Postgres`/`PgRow` with `MySql`/`MySqlRow` in type names):
+
+- `MySqlRdbcItemReader<'a, I>` → `MySqlRdbcItemReader<I>`
+- `query: &'a str` → `query: String`
+- `impl<'a, I> MySqlRdbcItemReader<'a, I>` → `impl<I> MySqlRdbcItemReader<I>`
+- `new(pool, query: &'a str, ...)` → `new(pool, query: String, ...)`
+- `impl<I> ItemReader<I> for MySqlRdbcItemReader<'_, I>` → `MySqlRdbcItemReader<I>`
+
+- [ ] **Step 2.3: Migrate `sqlite_reader.rs`**
+
+Apply the identical changes to `src/item/rdbc/sqlite_reader.rs` (replace with `Sqlite`/`SqliteRow`):
+
+- `SqliteRdbcItemReader<'a, I>` → `SqliteRdbcItemReader<I>`
+- `query: &'a str` → `query: String`
+- `impl<'a, I> SqliteRdbcItemReader<'a, I>` → `impl<I> SqliteRdbcItemReader<I>`
+- `new(pool, query: &'a str, ...)` → `new(pool, query: String, ...)`
+- `impl<I> ItemReader<I> for SqliteRdbcItemReader<'_, I>` → `SqliteRdbcItemReader<I>`
+- In the test helper `make_reader`: `SqliteRdbcItemReader::<Row>::new(pool, query, ...)` → add `.to_string()` to the query argument
+- In all test calls that pass a `&str` query to `SqliteRdbcItemReader::new`, add `.to_string()`
+
+Specifically in `sqlite_reader.rs` tests, these lines change:
+```rust
+// Old
+fn make_reader(pool: SqlitePool, query: &str, page_size: Option<i32>) -> SqliteRdbcItemReader<'_, Row> {
+    SqliteRdbcItemReader::<Row>::new(pool, query, page_size, None, None)
+}
+
+// New
+fn make_reader(pool: SqlitePool, query: &str, page_size: Option<i32>) -> SqliteRdbcItemReader<Row> {
+    SqliteRdbcItemReader::<Row>::new(pool, query.to_string(), page_size, None, None)
+}
+```
+
+And the two tests that call `SqliteRdbcItemReader::new` directly with `"SELECT id, name FROM items"`:
+```rust
+// Old
+let reader = SqliteRdbcItemReader::<Row>::new(
+    pool,
+    "SELECT id, name FROM items",
+    Some(2),
+    ...
+);
+
+// New
+let reader = SqliteRdbcItemReader::<Row>::new(
+    pool,
+    "SELECT id, name FROM items".to_string(),
+    Some(2),
+    ...
+);
+```
+
+- [ ] **Step 2.4: Run tests to verify no regressions**
+
+```bash
+cargo test --features rdbc-sqlite -p sbrs-lib 2>&1
+```
+
+Expected: all existing reader and builder tests PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/item/rdbc/postgres_reader.rs src/item/rdbc/mysql_reader.rs src/item/rdbc/sqlite_reader.rs
+git commit -m "refactor(rdbc): readers own their query String, remove 'a lifetime"
+```
+
+---
+
+## Task 3: Add `QuerySource` and `.select()` to `RdbcItemReaderBuilder`
+
+**Files:**
+- Modify: `src/item/rdbc/unified_reader_builder.rs`
+
+- [ ] **Step 3.1: Write the failing tests first**
+
+Add these tests to the `#[cfg(test)]` block in `unified_reader_builder.rs` (after the existing tests):
+
+```rust
+#[tokio::test(flavor = "multi_thread")]
+async fn should_build_sqlite_reader_from_select_builder() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let reader = RdbcItemReaderBuilder::<Dummy>::new()
+        .sqlite(pool)
+        .select(
+            SelectBuilder::from("items")
+                .columns(&["id"])
+                .where_eq("active", true)
+                .order_by_asc("id"),
+        )
+        .build_sqlite();
+    assert_eq!(
+        reader.query,
+        "SELECT id FROM items WHERE active = true ORDER BY id ASC",
+        "select builder SQL should be stored in reader"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_propagate_keyset_from_select_builder_to_sqlite_reader() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let reader = RdbcItemReaderBuilder::<Dummy>::new()
+        .sqlite(pool)
+        .select(
+            SelectBuilder::from("items")
+                .order_by_keyset("id", |d: &Dummy| d.id.to_string()),
+        )
+        .with_page_size(10)
+        .build_sqlite();
+    assert_eq!(
+        reader.keyset_column.as_deref(),
+        Some("id"),
+        "keyset column should propagate from SelectBuilder"
+    );
+    assert!(
+        reader.keyset_key.is_some(),
+        "keyset key fn should propagate from SelectBuilder"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_prefer_select_over_query_when_called_last() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let reader = RdbcItemReaderBuilder::<Dummy>::new()
+        .sqlite(pool.clone())
+        .query("SELECT id FROM old_table")
+        .select(SelectBuilder::from("new_table").columns(&["id"]))
+        .build_sqlite();
+    assert_eq!(
+        reader.query, "SELECT id FROM new_table",
+        "select() called last should win"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_prefer_query_over_select_when_called_last() {
+    let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+    let reader = RdbcItemReaderBuilder::<Dummy>::new()
+        .sqlite(pool)
+        .select(SelectBuilder::from("old_table").columns(&["id"]))
+        .query("SELECT id FROM new_table")
+        .build_sqlite();
+    assert_eq!(
+        reader.query, "SELECT id FROM new_table",
+        "query() called last should win"
+    );
+}
+```
+
+- [ ] **Step 3.2: Run the new tests — expect failure**
+
+```bash
+cargo test should_build_sqlite_reader_from_select_builder --features rdbc-sqlite -p sbrs-lib 2>&1
+```
+
+Expected: compile error — `.select()` method not found.
+
+- [ ] **Step 3.3: Add `QuerySource` enum and update the builder struct**
+
+At the top of `unified_reader_builder.rs`, add the import for `SelectBuilder`:
+
+```rust
+use super::select_builder::SelectBuilder;
+```
+
+Add the `QuerySource` enum after the imports:
+
+```rust
+enum QuerySource<'a> {
+    Raw(&'a str),
+    Built(String),
+}
+```
+
+In `RdbcItemReaderBuilder`, replace:
+
+```rust
+query: Option<&'a str>,
+```
+
+with:
+
+```rust
+query_source: Option<QuerySource<'a>>,
+```
+
+In `RdbcItemReaderBuilder::new()`, replace:
+
+```rust
+query: None,
+```
+
+with:
+
+```rust
+query_source: None,
+```
+
+- [ ] **Step 3.4: Update `.query()` method and add `.select()` method**
+
+Replace the existing `.query()` method:
+
+```rust
+pub fn query(mut self, query: &'a str) -> Self {
+    self.query_source = Some(QuerySource::Raw(query));
+    self
+}
+```
+
+Add `.select()` right after `.query()`:
+
+```rust
+/// Sets the query using a [`SelectBuilder`] instead of a raw SQL string.
+///
+/// If the [`SelectBuilder`] was configured with [`SelectBuilder::order_by_keyset`],
+/// keyset pagination is enabled automatically — no need to call `.with_keyset()`.
+///
+/// Calling `.select()` after `.query()` (or vice-versa) uses the last call.
+///
+/// # Examples
+///
+/// ```no_run
+/// use spring_batch_rs::item::rdbc::{RdbcItemReaderBuilder, SelectBuilder};
+/// use sqlx::SqlitePool;
+///
+/// # #[derive(sqlx::FromRow, Clone)]
+/// # struct Item { id: i32, name: String }
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let pool = SqlitePool::connect("sqlite::memory:").await?;
+///
+/// let reader = RdbcItemReaderBuilder::<Item>::new()
+///     .sqlite(pool)
+///     .select(
+///         SelectBuilder::from("items")
+///             .columns(&["id", "name"])
+///             .where_eq("active", true)
+///             .order_by_keyset("id", |i: &Item| i.id.to_string()),
+///     )
+///     .with_page_size(100)
+///     .build_sqlite();
+/// # Ok(())
+/// # }
+/// ```
+pub fn select(mut self, builder: SelectBuilder<I>) -> Self {
+    if let Some(col) = builder.keyset_column {
+        self.keyset_column = Some(col);
+    }
+    if let Some(key_fn) = builder.keyset_key_fn {
+        self.keyset_key_fn = Some(key_fn);
+    }
+    self.query_source = Some(QuerySource::Built(builder.build_sql()));
+    self
+}
+```
+
+> Note: `builder.build_sql()` is called before `builder.keyset_column` and `builder.keyset_key_fn` are moved out, but since `build_sql` takes `&self` we need to call it on a reference or restructure. Move the `build_sql` call to happen on a reference before destructuring. Adjust to:
+
+```rust
+pub fn select(mut self, builder: SelectBuilder<I>) -> Self {
+    let sql = builder.build_sql();
+    if let Some(col) = builder.keyset_column {
+        self.keyset_column = Some(col);
+    }
+    if let Some(key_fn) = builder.keyset_key_fn {
+        self.keyset_key_fn = Some(key_fn);
+    }
+    self.query_source = Some(QuerySource::Built(sql));
+    self
+}
+```
+
+- [ ] **Step 3.5: Update `build_postgres`, `build_mysql`, `build_sqlite` to use `query_source`**
+
+Add this helper at the top of each `impl` block that has a `build_*` method, or as a method on the builder:
+
+In each `build_*` method, replace:
+
+```rust
+self.query.expect("Query is required"),
+```
+
+with:
+
+```rust
+match self.query_source.expect("Query is required — call .query() or .select()") {
+    QuerySource::Raw(s) => s.to_string(),
+    QuerySource::Built(s) => s,
+},
+```
+
+Full updated `build_postgres`:
+
+```rust
+pub fn build_postgres(self) -> PostgresRdbcItemReader<I> {
+    let query = match self.query_source.expect("Query is required — call .query() or .select()") {
+        QuerySource::Raw(s) => s.to_string(),
+        QuerySource::Built(s) => s,
+    };
+    PostgresRdbcItemReader::new(
+        self.postgres_pool.expect("PostgreSQL pool is required"),
+        query,
+        self.page_size,
+        self.keyset_column,
+        self.keyset_key_fn,
+    )
+}
+```
+
+Full updated `build_mysql`:
+
+```rust
+pub fn build_mysql(self) -> MySqlRdbcItemReader<I> {
+    let query = match self.query_source.expect("Query is required — call .query() or .select()") {
+        QuerySource::Raw(s) => s.to_string(),
+        QuerySource::Built(s) => s,
+    };
+    MySqlRdbcItemReader::new(
+        self.mysql_pool.expect("MySQL pool is required"),
+        query,
+        self.page_size,
+        self.keyset_column,
+        self.keyset_key_fn,
+    )
+}
+```
+
+Full updated `build_sqlite`:
+
+```rust
+pub fn build_sqlite(self) -> SqliteRdbcItemReader<I> {
+    let query = match self.query_source.expect("Query is required — call .query() or .select()") {
+        QuerySource::Raw(s) => s.to_string(),
+        QuerySource::Built(s) => s,
+    };
+    SqliteRdbcItemReader::new(
+        self.sqlite_pool.expect("SQLite pool is required"),
+        query,
+        self.page_size,
+        self.keyset_column,
+        self.keyset_key_fn,
+    )
+}
+```
+
+- [ ] **Step 3.6: Update the existing panic tests**
+
+The existing tests that use `.expect("Query is required")` in the panic message need to match the new message. Update these tests:
+
+```rust
+#[test]
+#[should_panic(expected = "Query is required")]
+fn should_panic_when_building_sqlite_without_pool() { ... }
+
+#[test]
+#[should_panic(expected = "Query is required")]
+fn should_panic_when_building_postgres_without_pool() { ... }
+
+#[test]
+#[should_panic(expected = "Query is required")]
+fn should_panic_when_building_mysql_without_pool() { ... }
+```
+
+These tests panic because of "PostgreSQL pool is required" / "MySQL pool is required" etc. — they don't reach the query check, so those tests are unaffected. The tests that test missing query (if any) may need their expected message updated. Verify by running the tests.
+
+- [ ] **Step 3.7: Run all tests**
+
+```bash
+cargo test --features rdbc-sqlite -p sbrs-lib 2>&1
+```
+
+Expected: all tests PASS including the new `should_build_sqlite_reader_from_select_builder` and `should_propagate_keyset_from_select_builder_to_sqlite_reader`.
+
+- [ ] **Step 3.8: Commit**
+
+```bash
+git add src/item/rdbc/unified_reader_builder.rs
+git commit -m "feat(rdbc): add .select() method to RdbcItemReaderBuilder with QuerySource"
+```
+
+---
+
+## Task 4: Final verification
+
+- [ ] **Step 4.1: Run full test suite**
+
+```bash
+cargo test --all-features -p sbrs-lib 2>&1
+```
+
+Expected: all tests PASS.
+
+- [ ] **Step 4.2: Check clippy**
+
+```bash
+cargo clippy --all-features -p sbrs-lib -- -D warnings 2>&1
+```
+
+Expected: zero warnings.
+
+- [ ] **Step 4.3: Check doc tests**
+
+```bash
+cargo test --doc --all-features -p sbrs-lib 2>&1
+```
+
+Expected: all doc tests PASS.
+
+- [ ] **Step 4.4: Commit**
+
+```bash
+git add .
+git commit -m "chore(rdbc): verify SelectBuilder builds and tests clean"
+```
+
+---
+
+## Self-Review Against Spec
+
+| Spec requirement | Covered by |
+|---|---|
+| `SelectBuilder<I>` in `select_builder.rs` | Task 1 |
+| `from()`, `columns()`, all `where_*` methods | Task 1 |
+| `order_by_asc`, `order_by_desc` | Task 1 |
+| `order_by_keyset` replaces prior order, stores keyset | Task 1 |
+| `build_sql()` generates correct SQL | Task 1 tests |
+| `ConditionValue` with `Into` impls for all primitives | Task 1 |
+| `QuerySource` enum in builder | Task 3 |
+| `.select()` on `RdbcItemReaderBuilder` | Task 3 |
+| `.select()` propagates keyset column + key_fn | Task 3 |
+| `.query()` still works (Raw path) | Task 3 |
+| Last-call-wins for `.query()` vs `.select()` | Task 3 tests |
+| Readers own their query (`String`) | Task 2 |
+| `SelectBuilder` exported from `mod.rs` | Task 1 step 1.4 |
+| Existing integration tests unbroken | Task 2 step 2.4, Task 4 |

--- a/docs/superpowers/specs/2026-05-15-rdbc-column-mapping-design.md
+++ b/docs/superpowers/specs/2026-05-15-rdbc-column-mapping-design.md
@@ -1,0 +1,200 @@
+# Design: RDBC Column Mapping API
+
+**Date:** 2026-05-15  
+**Status:** Approved  
+**Scope:** `sbrs-lib` — `src/item/rdbc/`
+
+---
+
+## Problem
+
+The RDBC writer requires users to implement the `DatabaseItemBinder<O, DB>` trait manually for each item type. This means:
+
+- Boilerplate per struct: implement `bind()` for each database backend separately
+- The builder has three binder fields (`postgres_binder`, `mysql_binder`, `sqlite_binder`) and three setter methods, one per database
+- Adding or removing a column requires modifying the trait impl
+- The trait is generic over `DB` (the sqlx database type), which leaks sqlx internals into user code
+
+## Goal
+
+Replace `DatabaseItemBinder` entirely with a fluent `.column(name, extractor)` method on `RdbcItemWriterBuilder`. The extractor closure maps an item to a `ColumnValue` — a type-erased enum covering all primitive sqlx types plus `Null` for `Option<T>`.
+
+---
+
+## Design
+
+### 1. `ColumnValue` enum
+
+New file: `src/item/rdbc/column_value.rs`
+
+```rust
+pub enum ColumnValue {
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Bool(bool),
+    Bytes(Vec<u8>),
+    Null,
+}
+```
+
+#### `From` implementations
+
+| Source type | `ColumnValue` variant |
+|---|---|
+| `i32`, `i64` | `Int` |
+| `f32`, `f64` | `Float` |
+| `bool` | `Bool` |
+| `&str`, `String` | `Text` |
+| `Vec<u8>` | `Bytes` |
+| `Option<T: Into<ColumnValue>>` | `Null` (when `None`) or delegates to `T` (when `Some`) |
+
+String values are stored as-is (no escaping needed — values go through `push_bind`, not string concatenation).
+
+---
+
+### 2. `RdbcItemWriterBuilder` changes
+
+File: `src/item/rdbc/unified_writer_builder.rs`
+
+#### Removed
+
+- Fields: `postgres_binder`, `mysql_binder`, `sqlite_binder`
+- Methods: `.postgres_binder()`, `.mysql_binder()`, `.sqlite_binder()`
+
+#### Added
+
+```rust
+column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>
+```
+
+```rust
+pub fn column(mut self, name: &str, extractor: impl Fn(&O) -> ColumnValue + 'static) -> Self {
+    self.column_bindings.push((name.to_string(), Box::new(extractor)));
+    self
+}
+```
+
+The accumulated `column_bindings` list is passed to all three writer constructors (Postgres, MySQL, SQLite) at build time. Column order in the INSERT matches the order of `.column()` calls.
+
+---
+
+### 3. Writer struct changes
+
+Files: `postgres_writer.rs`, `mysql_writer.rs`, `sqlite_writer.rs`
+
+#### Removed
+
+- `item_binder: Option<&'a dyn DatabaseItemBinder<O, DB>>` field and its lifetime `'a`
+- The `'a` lifetime parameter on the writer struct and its `impl` blocks
+
+#### Added
+
+```rust
+column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>
+```
+
+#### `write()` implementation
+
+```rust
+push_values(items, |mut b, item| {
+    for (_, extractor) in &self.column_bindings {
+        match extractor(item) {
+            ColumnValue::Int(v)   => { b.push_bind(v); }
+            ColumnValue::Float(v) => { b.push_bind(v); }
+            ColumnValue::Text(v)  => { b.push_bind(v); }
+            ColumnValue::Bool(v)  => { b.push_bind(v); }
+            ColumnValue::Bytes(v) => { b.push_bind(v); }
+            ColumnValue::Null     => { b.push_bind(Option::<String>::None); }
+        }
+    }
+})
+```
+
+The INSERT column list is built from the `column_bindings` names:
+```sql
+INSERT INTO table (col1, col2, col3) VALUES (?, ?, ?), ...
+```
+
+---
+
+### 4. `DatabaseItemBinder` removal
+
+File: `src/item/rdbc/writer_common.rs`
+
+The `DatabaseItemBinder<O, DB>` trait is deleted entirely. No deprecation shim — this is a clean break.
+
+---
+
+### 5. Module exports
+
+`src/item/rdbc/mod.rs`:
+
+```rust
+pub use column_value::ColumnValue;
+// Remove: pub use writer_common::DatabaseItemBinder;
+```
+
+---
+
+## Usage example
+
+```rust
+RdbcItemWriterBuilder::<User>::new()
+    .postgres(pool)
+    .table("users")
+    .column("id", |u: &User| u.id.into())
+    .column("name", |u: &User| u.name.as_str().into())
+    .column("score", |u: &User| u.score.map(|s| s as f64).into())
+    .column("avatar", |u: &User| u.avatar.clone().map(ColumnValue::Bytes).unwrap_or(ColumnValue::Null))
+    .build_postgres();
+```
+
+---
+
+## Files to create / modify
+
+| File | Action |
+|---|---|
+| `src/item/rdbc/column_value.rs` | Create |
+| `src/item/rdbc/unified_writer_builder.rs` | Modify — add `.column()`, remove binder fields/methods |
+| `src/item/rdbc/postgres_writer.rs` | Modify — replace `item_binder` with `column_bindings` |
+| `src/item/rdbc/mysql_writer.rs` | Modify — replace `item_binder` with `column_bindings` |
+| `src/item/rdbc/sqlite_writer.rs` | Modify — replace `item_binder` with `column_bindings` |
+| `src/item/rdbc/writer_common.rs` | Modify — delete `DatabaseItemBinder` trait |
+| `src/item/rdbc/mod.rs` | Modify — export `ColumnValue`, remove `DatabaseItemBinder` |
+| `tests/rdbc_postgres.rs` | Modify — rewrite writer tests with `.column()` |
+| `tests/rdbc_mysql.rs` | Modify — rewrite writer tests with `.column()` |
+| `tests/rdbc_sqlite.rs` | Modify — rewrite writer tests with `.column()` |
+| `examples/` | Modify — update examples that use `DatabaseItemBinder` |
+
+Writers and the three database-specific readers are not touched beyond removing the binder lifetime.
+
+---
+
+## Testing
+
+### `column_value.rs` unit tests (`#[cfg(test)]`)
+
+- Each `From` impl: `i32 → Int`, `f64 → Float`, `&str → Text`, `bool → Bool`, `Vec<u8> → Bytes`
+- `Option<T>`: `Some(42i32)` → `Int(42)`, `None::<i32>` → `Null`
+
+### Writer struct unit tests (inline, no DB)
+
+- `should_store_column_bindings_in_order` — `.column()` calls accumulate in order
+- `should_return_null_for_none_option` — `Option::None` → `ColumnValue::Null`
+
+### Integration tests (`tests/rdbc_*.rs`)
+
+- Existing write tests rewritten to use `.column()` instead of `DatabaseItemBinder` — same assertions, new API
+- Add `should_write_row_with_null_optional_column` — inserts a row with `Option::None`, reads it back, asserts NULL in DB
+
+---
+
+## Non-goals (explicit)
+
+- No parameterized binding for reads (`SelectBuilder` handles that separately)
+- No `OR` conditions or composite column expressions
+- No upsert / conflict resolution support
+- No batch size tuning (already handled by chunk size)
+- No backwards compatibility with `DatabaseItemBinder`

--- a/docs/superpowers/specs/2026-05-15-rdbc-select-builder-design.md
+++ b/docs/superpowers/specs/2026-05-15-rdbc-select-builder-design.md
@@ -1,0 +1,212 @@
+# Design: RDBC SelectBuilder
+
+**Date:** 2026-05-15  
+**Status:** Approved  
+**Scope:** `sbrs-lib` — `src/item/rdbc/`
+
+---
+
+## Problem
+
+The RDBC reader currently requires a raw SQL string via `.query("SELECT ...")`. This means:
+
+- Users write SQL inline in Rust builder chains
+- Pagination clauses (LIMIT/OFFSET, keyset WHERE/ORDER BY) are appended by string concatenation inside the reader
+- Keyset pagination requires two separate calls: `.query(...)` + `.with_keyset(col, key_fn)`, which are conceptually one concern
+
+## Goal
+
+Provide an optional fluent `SelectBuilder` that generates the base SQL string for simple queries. The raw `.query()` path remains fully supported for complex cases (JOINs, subqueries, CTEs).
+
+---
+
+## Design
+
+### 1. `SelectBuilder<I>`
+
+New file: `src/item/rdbc/select_builder.rs`
+
+A **database-agnostic** struct that generates a SQL `SELECT` string. Generic over `I` (the item type) only to carry the keyset `key_fn` closure when `order_by_keyset` is used.
+
+```rust
+pub struct SelectBuilder<I> {
+    table: String,
+    columns: Vec<String>,          // empty → SELECT *
+    conditions: Vec<WhereClause>,  // joined with AND
+    order_by: Vec<OrderClause>,
+    keyset_column: Option<String>,
+    keyset_key_fn: Option<Box<dyn Fn(&I) -> String>>,
+}
+```
+
+#### Constructor
+
+```rust
+SelectBuilder::from("users")   // sets table
+```
+
+#### Column selection
+
+```rust
+.columns(&["id", "name", "email"])  // omit → SELECT *
+```
+
+#### WHERE conditions
+
+All values go through `impl Into<ConditionValue>`. Blanket impls cover `i32`, `i64`, `f64`, `bool`, `&str`, `String`.
+
+| Method | SQL fragment |
+|---|---|
+| `.where_eq("col", val)` | `col = 'val'` / `col = 42` |
+| `.where_not_eq("col", val)` | `col != 'val'` |
+| `.where_gt("col", val)` | `col > val` |
+| `.where_gte("col", val)` | `col >= val` |
+| `.where_lt("col", val)` | `col < val` |
+| `.where_lte("col", val)` | `col <= val` |
+| `.where_like("col", pat)` | `col LIKE 'pat'` |
+| `.where_is_null("col")` | `col IS NULL` |
+| `.where_is_not_null("col")` | `col IS NOT NULL` |
+
+Multiple conditions are combined with `AND`.
+
+String values are escaped via `replace('\'', "''")` before inlining. Integer, float, and bool values are inlined directly (no injection risk).
+
+#### Ordering / keyset
+
+```rust
+// Simple ordering (no keyset)
+.order_by_asc("created_at")
+.order_by_desc("score")
+
+// Keyset ordering — sets ORDER BY + keyset column + key extractor
+.order_by_keyset("id", |u: &User| u.id.to_string())
+```
+
+`order_by_keyset` replaces the need to separately call `.with_keyset()` on the reader builder. Only one keyset column is supported. Calling `order_by_keyset` after another `order_by_*` replaces all previous order clauses.
+
+#### SQL generation
+
+```rust
+pub fn build_sql(&self) -> String
+```
+
+Produces: `SELECT col1, col2 FROM table [WHERE ...] [ORDER BY ...]`
+
+Does **not** append LIMIT/OFFSET or keyset WHERE — those remain the reader's responsibility.
+
+#### `ConditionValue` enum (internal)
+
+```rust
+enum ConditionValue {
+    Integer(i64),
+    Float(f64),
+    Text(String),
+    Bool(bool),
+}
+```
+
+---
+
+### 2. `RdbcItemReaderBuilder` changes
+
+File: `src/item/rdbc/unified_reader_builder.rs`
+
+#### New `QuerySource` enum (internal)
+
+```rust
+enum QuerySource<'a> {
+    Raw(&'a str),
+    Built(String),
+}
+```
+
+Replaces the current `query: Option<&'a str>` field. Both paths produce the same SQL string at build time.
+
+#### New `.select()` method
+
+```rust
+pub fn select(mut self, builder: SelectBuilder<I>) -> Self
+```
+
+- Calls `builder.build_sql()`, stores result as `QuerySource::Built`
+- If `builder.keyset_column` is `Some`, propagates `keyset_column` and `keyset_key_fn` to the reader (overrides any prior `.with_keyset()` call)
+
+#### `.query()` unchanged
+
+```rust
+pub fn query(mut self, query: &'a str) -> Self
+```
+
+Still works, stores `QuerySource::Raw`. `.with_keyset()` on the builder remains available for `.query()` users.
+
+---
+
+### 3. Module exports
+
+`src/item/rdbc/mod.rs` re-exports `SelectBuilder`:
+
+```rust
+pub use select_builder::SelectBuilder;
+```
+
+---
+
+## Usage examples
+
+### Simple filter + keyset (new path)
+
+```rust
+let reader = RdbcItemReaderBuilder::<User>::new()
+    .postgres(pool)
+    .select(
+        SelectBuilder::from("users")
+            .columns(&["id", "name", "email"])
+            .where_eq("status", "ACTIVE")
+            .where_is_null("deleted_at")
+            .order_by_keyset("id", |u: &User| u.id.to_string())
+    )
+    .with_page_size(1_000)
+    .build_postgres();
+```
+
+Generated SQL before pagination: `SELECT id, name, email FROM users WHERE status = 'ACTIVE' AND deleted_at IS NULL ORDER BY id ASC`
+
+### Complex join (existing path, unchanged)
+
+```rust
+let reader = RdbcItemReaderBuilder::<UserWithRole>::new()
+    .postgres(pool)
+    .query("SELECT u.id, u.name, r.name AS role FROM users u JOIN roles r ON u.role_id = r.id")
+    .with_page_size(500)
+    .with_keyset("id", |u: &UserWithRole| u.id.to_string())
+    .build_postgres();
+```
+
+---
+
+## Files to create / modify
+
+| File | Action |
+|---|---|
+| `src/item/rdbc/select_builder.rs` | Create |
+| `src/item/rdbc/unified_reader_builder.rs` | Modify — add `QuerySource`, `.select()` |
+| `src/item/rdbc/mod.rs` | Modify — export `SelectBuilder` |
+
+Writers and the three database-specific readers (`postgres_reader.rs`, `mysql_reader.rs`, `sqlite_reader.rs`) are **not touched**.
+
+---
+
+## Testing
+
+- `select_builder.rs` gets a `#[cfg(test)]` module covering: `build_sql` output for each condition type, empty columns (SELECT *), multiple conditions, keyset + order interaction
+- `unified_reader_builder.rs` tests extended: `.select()` propagates keyset, `.select()` and `.query()` are mutually exclusive (last wins)
+- Existing integration tests (`tests/rdbc_*.rs`) continue to pass unchanged
+
+---
+
+## Non-goals (explicit)
+
+- No parameterized bindings (`push_bind`) in this iteration — strings are escaped inline
+- No OR conditions, no nested conditions
+- No JOIN support in `SelectBuilder`
+- Writer-side improvements are out of scope for this spec

--- a/examples/benchmark_csv_postgres_xml.rs
+++ b/examples/benchmark_csv_postgres_xml.rs
@@ -34,11 +34,11 @@ use spring_batch_rs::{
     },
     item::{
         csv::csv_reader::CsvItemReaderBuilder,
-        rdbc::{DatabaseItemBinder, RdbcItemReaderBuilder, RdbcItemWriterBuilder},
+        rdbc::{RdbcItemReaderBuilder, RdbcItemWriterBuilder},
         xml::{xml_reader::XmlItemReaderBuilder, xml_writer::XmlItemWriterBuilder},
     },
 };
-use sqlx::{FromRow, PgPool, Postgres, query_builder::Separated};
+use sqlx::{FromRow, PgPool};
 use std::{
     env,
     fs::File,
@@ -102,42 +102,6 @@ impl ItemProcessor<Transaction, Transaction> for TransactionProcessor {
             status,
             amount_eur: (item.amount * rate * 100.0).round() / 100.0,
         }))
-    }
-}
-
-// =============================================================================
-// PostgreSQL Binder
-// =============================================================================
-
-/// Binds `Transaction` fields to a PostgreSQL bulk-insert query.
-struct TransactionBinder;
-
-impl DatabaseItemBinder<Transaction, Postgres> for TransactionBinder {
-    fn bind(&self, item: &Transaction, mut q: Separated<Postgres, &str>) {
-        q.push_bind(item.transaction_id.clone());
-        q.push_bind(item.amount);
-        q.push_bind(item.currency.clone());
-        q.push_bind(item.timestamp.clone());
-        q.push_bind(item.account_from.clone());
-        q.push_bind(item.account_to.clone());
-        q.push_bind(item.status.clone());
-        q.push_bind(item.amount_eur);
-    }
-}
-
-/// Binds `Transaction` fields to a PostgreSQL bulk-insert for `transactions_import`.
-struct TransactionImportBinder;
-
-impl DatabaseItemBinder<Transaction, Postgres> for TransactionImportBinder {
-    fn bind(&self, item: &Transaction, mut q: Separated<Postgres, &str>) {
-        q.push_bind(item.transaction_id.clone());
-        q.push_bind(item.amount);
-        q.push_bind(item.currency.clone());
-        q.push_bind(item.timestamp.clone());
-        q.push_bind(item.account_from.clone());
-        q.push_bind(item.account_to.clone());
-        q.push_bind(item.status.clone());
-        q.push_bind(item.amount_eur);
     }
 }
 
@@ -344,19 +308,21 @@ fn run_step1(pool: &PgPool, csv_path: &str) -> Result<u64, BatchError> {
         .has_headers(true)
         .from_reader(buffered);
 
-    let binder = TransactionBinder;
     let writer = RdbcItemWriterBuilder::<Transaction>::new()
         .postgres(pool)
         .table("transactions")
-        .add_column("transaction_id")
-        .add_column("amount")
-        .add_column("currency")
-        .add_column("timestamp")
-        .add_column("account_from")
-        .add_column("account_to")
-        .add_column("status")
-        .add_column("amount_eur")
-        .postgres_binder(&binder)
+        .column("transaction_id", |t: &Transaction| {
+            t.transaction_id.clone().into()
+        })
+        .column("amount", |t: &Transaction| t.amount.into())
+        .column("currency", |t: &Transaction| t.currency.clone().into())
+        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
+        .column("account_from", |t: &Transaction| {
+            t.account_from.clone().into()
+        })
+        .column("account_to", |t: &Transaction| t.account_to.clone().into())
+        .column("status", |t: &Transaction| t.status.clone().into())
+        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
         .build_postgres();
 
     let processor = TransactionProcessor;
@@ -467,19 +433,21 @@ fn run_step3(pool: &PgPool, xml_path: &str) -> Result<u64, BatchError> {
         .from_path(xml_path)
         .map_err(|e| BatchError::ItemReader(e.to_string()))?;
 
-    let binder = TransactionImportBinder;
     let writer = RdbcItemWriterBuilder::<Transaction>::new()
         .postgres(pool)
         .table("transactions_import")
-        .add_column("transaction_id")
-        .add_column("amount")
-        .add_column("currency")
-        .add_column("timestamp")
-        .add_column("account_from")
-        .add_column("account_to")
-        .add_column("status")
-        .add_column("amount_eur")
-        .postgres_binder(&binder)
+        .column("transaction_id", |t: &Transaction| {
+            t.transaction_id.clone().into()
+        })
+        .column("amount", |t: &Transaction| t.amount.into())
+        .column("currency", |t: &Transaction| t.currency.clone().into())
+        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
+        .column("account_from", |t: &Transaction| {
+            t.account_from.clone().into()
+        })
+        .column("account_to", |t: &Transaction| t.account_to.clone().into())
+        .column("status", |t: &Transaction| t.status.clone().into())
+        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
         .build_postgres();
 
     let processor = PassThroughProcessor::<Transaction>::new();

--- a/examples/benchmark_csv_postgres_xml.rs
+++ b/examples/benchmark_csv_postgres_xml.rs
@@ -38,7 +38,7 @@ use spring_batch_rs::{
         xml::{xml_reader::XmlItemReaderBuilder, xml_writer::XmlItemWriterBuilder},
     },
 };
-use sqlx::{FromRow, PgPool};
+use sqlx::FromRow;
 use std::{
     env,
     fs::File,
@@ -207,7 +207,7 @@ mod tests {
     fn should_convert_usd_to_eur() {
         let processor = TransactionProcessor;
         let input = make_transaction("USD", 1000.0, "COMPLETED");
-        let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+        let result = processor.process(input).unwrap().unwrap(); // process() always returns Ok(Some(_))
         assert_eq!(result.amount_eur, 920.0, "USD 1000 * 0.92 = EUR 920");
         assert_eq!(result.currency, "USD", "currency field must not change");
     }
@@ -216,7 +216,7 @@ mod tests {
     fn should_convert_gbp_to_eur() {
         let processor = TransactionProcessor;
         let input = make_transaction("GBP", 100.0, "COMPLETED");
-        let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+        let result = processor.process(input).unwrap().unwrap();
         assert_eq!(result.amount_eur, 117.0, "GBP 100 * 1.17 = EUR 117");
     }
 
@@ -224,7 +224,7 @@ mod tests {
     fn should_keep_eur_unchanged() {
         let processor = TransactionProcessor;
         let input = make_transaction("EUR", 500.0, "PENDING");
-        let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+        let result = processor.process(input).unwrap().unwrap();
         assert_eq!(result.amount_eur, 500.0, "EUR passthrough: rate = 1.0");
     }
 
@@ -232,7 +232,7 @@ mod tests {
     fn should_normalise_cancelled_to_failed() {
         let processor = TransactionProcessor;
         let input = make_transaction("EUR", 100.0, "CANCELLED");
-        let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+        let result = processor.process(input).unwrap().unwrap();
         assert_eq!(
             result.status, "FAILED",
             "CANCELLED must be mapped to FAILED"
@@ -244,7 +244,7 @@ mod tests {
         let processor = TransactionProcessor;
         for status in &["PENDING", "COMPLETED", "FAILED"] {
             let input = make_transaction("EUR", 100.0, status);
-            let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+            let result = processor.process(input).unwrap().unwrap();
             assert_eq!(
                 &result.status, status,
                 "status '{}' must not be changed",
@@ -258,7 +258,7 @@ mod tests {
         let processor = TransactionProcessor;
         // 333.33 * 0.92 = 306.6636 → rounds to 306.66
         let input = make_transaction("USD", 333.33, "COMPLETED");
-        let result = processor.process(input).unwrap(); // unwrap: process() always returns Ok
+        let result = processor.process(input).unwrap().unwrap();
         assert!(
             (result.amount_eur - 306.66_f64).abs() < 1e-9,
             "amount_eur must be rounded to 2 decimals, got {}",
@@ -290,198 +290,6 @@ mod tests {
             lines.len()
         );
     }
-}
-
-// =============================================================================
-// Step 1 — CSV → PostgreSQL
-// =============================================================================
-
-fn run_step1(pool: &PgPool, csv_path: &str) -> Result<u64, BatchError> {
-    log::info!("[Step 1] CSV → PostgreSQL …");
-    let t0 = Instant::now();
-
-    let file = File::open(csv_path)
-        .map_err(|e| BatchError::ItemReader(format!("Cannot open CSV: {}", e)))?;
-    let buffered = BufReader::with_capacity(64 * 1024, file);
-
-    let reader = CsvItemReaderBuilder::<Transaction>::new()
-        .has_headers(true)
-        .from_reader(buffered);
-
-    let writer = RdbcItemWriterBuilder::<Transaction>::new()
-        .postgres(pool)
-        .table("transactions")
-        .column("transaction_id", |t: &Transaction| {
-            t.transaction_id.clone().into()
-        })
-        .column("amount", |t: &Transaction| t.amount.into())
-        .column("currency", |t: &Transaction| t.currency.clone().into())
-        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
-        .column("account_from", |t: &Transaction| {
-            t.account_from.clone().into()
-        })
-        .column("account_to", |t: &Transaction| t.account_to.clone().into())
-        .column("status", |t: &Transaction| t.status.clone().into())
-        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
-        .build_postgres();
-
-    let processor = TransactionProcessor;
-
-    let step = StepBuilder::new("csv-to-postgres")
-        .chunk::<Transaction, Transaction>(1_000)
-        .reader(&reader)
-        .processor(&processor)
-        .writer(&writer)
-        .build();
-
-    let job = JobBuilder::new().start(&step).build();
-    job.run()?;
-
-    // SAFETY: step "csv-to-postgres" is always registered after job.run() succeeds
-    let exec = job
-        .get_step_execution("csv-to-postgres")
-        .expect("step 'csv-to-postgres' must exist after job.run()");
-    let duration = t0.elapsed();
-    let throughput = exec.write_count as f64 / duration.as_secs_f64();
-
-    eprintln!(
-        "[Step 1] Done — {} records written in {:.1}s ({:.0} rec/s)",
-        exec.write_count,
-        duration.as_secs_f64(),
-        throughput
-    );
-    if exec.read_error_count > 0 || exec.write_error_count > 0 {
-        eprintln!(
-            "[Step 1] WARNING: {} read errors, {} write errors skipped — throughput may be understated",
-            exec.read_error_count, exec.write_error_count
-        );
-    }
-
-    Ok(exec.write_count as u64)
-}
-
-// =============================================================================
-// Step 2 — PostgreSQL → XML
-// =============================================================================
-
-fn run_step2(pool: &PgPool, xml_path: &str) -> Result<u64, BatchError> {
-    log::info!("[Step 2] PostgreSQL → XML …");
-    let t0 = Instant::now();
-
-    let reader = RdbcItemReaderBuilder::<Transaction>::new()
-        .postgres(pool.clone())
-        .query(
-            "SELECT transaction_id, amount, currency, timestamp, \
-             account_from, account_to, status, amount_eur \
-             FROM transactions",
-        )
-        .with_page_size(1_000)
-        .with_keyset("transaction_id", |t: &Transaction| t.transaction_id.clone())
-        .build_postgres();
-
-    let writer = XmlItemWriterBuilder::<Transaction>::new()
-        .root_tag("transactions")
-        .item_tag("transaction")
-        .from_path(xml_path)
-        .map_err(|e| BatchError::ItemWriter(e.to_string()))?;
-
-    let processor = PassThroughProcessor::<Transaction>::new();
-
-    let step = StepBuilder::new("postgres-to-xml")
-        .chunk::<Transaction, Transaction>(1_000)
-        .reader(&reader)
-        .processor(&processor)
-        .writer(&writer)
-        .build();
-
-    let job = JobBuilder::new().start(&step).build();
-    job.run()?;
-
-    // SAFETY: step "postgres-to-xml" is always registered after job.run() succeeds
-    let exec = job
-        .get_step_execution("postgres-to-xml")
-        .expect("step 'postgres-to-xml' must exist after job.run()");
-    let duration = t0.elapsed();
-    let throughput = exec.write_count as f64 / duration.as_secs_f64();
-
-    eprintln!(
-        "[Step 2] Done — {} records written in {:.1}s ({:.0} rec/s)",
-        exec.write_count,
-        duration.as_secs_f64(),
-        throughput
-    );
-    if exec.read_error_count > 0 || exec.write_error_count > 0 {
-        eprintln!(
-            "[Step 2] WARNING: {} read errors, {} write errors skipped — throughput may be understated",
-            exec.read_error_count, exec.write_error_count
-        );
-    }
-
-    Ok(exec.write_count as u64)
-}
-
-// =============================================================================
-// Step 3 — XML → PostgreSQL (transactions_import)
-// =============================================================================
-
-fn run_step3(pool: &PgPool, xml_path: &str) -> Result<u64, BatchError> {
-    log::info!("[Step 3] XML → PostgreSQL (transactions_import) …");
-    let t0 = Instant::now();
-
-    let reader = XmlItemReaderBuilder::<Transaction>::new()
-        .tag("transaction")
-        .from_path(xml_path)
-        .map_err(|e| BatchError::ItemReader(e.to_string()))?;
-
-    let writer = RdbcItemWriterBuilder::<Transaction>::new()
-        .postgres(pool)
-        .table("transactions_import")
-        .column("transaction_id", |t: &Transaction| {
-            t.transaction_id.clone().into()
-        })
-        .column("amount", |t: &Transaction| t.amount.into())
-        .column("currency", |t: &Transaction| t.currency.clone().into())
-        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
-        .column("account_from", |t: &Transaction| {
-            t.account_from.clone().into()
-        })
-        .column("account_to", |t: &Transaction| t.account_to.clone().into())
-        .column("status", |t: &Transaction| t.status.clone().into())
-        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
-        .build_postgres();
-
-    let processor = PassThroughProcessor::<Transaction>::new();
-
-    let step = StepBuilder::new("xml-to-postgres-import")
-        .chunk::<Transaction, Transaction>(1_000)
-        .reader(&reader)
-        .processor(&processor)
-        .writer(&writer)
-        .build();
-
-    let job = JobBuilder::new().start(&step).build();
-    job.run()?;
-
-    let exec = job
-        .get_step_execution("xml-to-postgres-import")
-        .expect("step 'xml-to-postgres-import' must exist after job.run()");
-    let duration = t0.elapsed();
-    let throughput = exec.write_count as f64 / duration.as_secs_f64();
-
-    eprintln!(
-        "[Step 3] Done — {} records written in {:.1}s ({:.0} rec/s)",
-        exec.write_count,
-        duration.as_secs_f64(),
-        throughput
-    );
-    if exec.read_error_count > 0 || exec.write_error_count > 0 {
-        eprintln!(
-            "[Step 3] WARNING: {} read errors, {} write errors skipped",
-            exec.read_error_count, exec.write_error_count
-        );
-    }
-
-    Ok(exec.write_count as u64)
 }
 
 // =============================================================================
@@ -582,19 +390,128 @@ async fn main() -> Result<(), BatchError> {
     eprintln!("[Generate] Done in {:.1}s", t_gen.elapsed().as_secs_f64());
     eprintln!();
 
-    // 6. Run Step 1
-    run_step1(&pool, &csv_path)?;
-    eprintln!();
+    // ── Step 1: CSV → PostgreSQL ──────────────────────────────────────────────
+    let file = File::open(&csv_path)
+        .map_err(|e| BatchError::ItemReader(format!("Cannot open CSV: {}", e)))?;
+    let csv_reader = CsvItemReaderBuilder::<Transaction>::new()
+        .has_headers(true)
+        .from_reader(BufReader::with_capacity(64 * 1024, file));
+    let pg_writer1 = RdbcItemWriterBuilder::<Transaction>::new()
+        .postgres(&pool)
+        .table("transactions")
+        .column("transaction_id", |t: &Transaction| {
+            t.transaction_id.clone().into()
+        })
+        .column("amount", |t: &Transaction| t.amount.into())
+        .column("currency", |t: &Transaction| t.currency.clone().into())
+        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
+        .column("account_from", |t: &Transaction| {
+            t.account_from.clone().into()
+        })
+        .column("account_to", |t: &Transaction| t.account_to.clone().into())
+        .column("status", |t: &Transaction| t.status.clone().into())
+        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+        .build_postgres();
+    let processor1 = TransactionProcessor;
+    let step1 = StepBuilder::new("csv-to-postgres")
+        .chunk::<Transaction, Transaction>(1_000)
+        .reader(&csv_reader)
+        .processor(&processor1)
+        .writer(&pg_writer1)
+        .build();
 
-    // 7. Run Step 2
-    run_step2(&pool, &xml_path)?;
-    eprintln!();
+    // ── Step 2: PostgreSQL → XML ──────────────────────────────────────────────
+    let pg_reader = RdbcItemReaderBuilder::<Transaction>::new()
+        .postgres(pool.clone())
+        .query(
+            "SELECT transaction_id, amount, currency, timestamp, \
+             account_from, account_to, status, amount_eur \
+             FROM transactions",
+        )
+        .with_page_size(1_000)
+        .with_keyset("transaction_id", |t: &Transaction| t.transaction_id.clone())
+        .build_postgres();
+    // xml_writer creates the file immediately — must be built before xml_reader (step 3)
+    let xml_writer = XmlItemWriterBuilder::<Transaction>::new()
+        .root_tag("transactions")
+        .item_tag("transaction")
+        .from_path(&xml_path)
+        .map_err(|e| BatchError::ItemWriter(e.to_string()))?;
+    let processor2 = PassThroughProcessor::<Transaction>::new();
+    let step2 = StepBuilder::new("postgres-to-xml")
+        .chunk::<Transaction, Transaction>(1_000)
+        .reader(&pg_reader)
+        .processor(&processor2)
+        .writer(&xml_writer)
+        .build();
 
-    // 8. Run Step 3
-    run_step3(&pool, &xml_path)?;
-    eprintln!();
+    // ── Step 3: XML → PostgreSQL (transactions_import) ───────────────────────
+    // xml_reader opens the file created above; content written by step 2 at runtime
+    let xml_reader = XmlItemReaderBuilder::<Transaction>::new()
+        .tag("transaction")
+        .from_path(&xml_path)
+        .map_err(|e| BatchError::ItemReader(e.to_string()))?;
+    let pg_writer2 = RdbcItemWriterBuilder::<Transaction>::new()
+        .postgres(&pool)
+        .table("transactions_import")
+        .column("transaction_id", |t: &Transaction| {
+            t.transaction_id.clone().into()
+        })
+        .column("amount", |t: &Transaction| t.amount.into())
+        .column("currency", |t: &Transaction| t.currency.clone().into())
+        .column("timestamp", |t: &Transaction| t.timestamp.clone().into())
+        .column("account_from", |t: &Transaction| {
+            t.account_from.clone().into()
+        })
+        .column("account_to", |t: &Transaction| t.account_to.clone().into())
+        .column("status", |t: &Transaction| t.status.clone().into())
+        .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+        .build_postgres();
+    let processor3 = PassThroughProcessor::<Transaction>::new();
+    let step3 = StepBuilder::new("xml-to-postgres-import")
+        .chunk::<Transaction, Transaction>(1_000)
+        .reader(&xml_reader)
+        .processor(&processor3)
+        .writer(&pg_writer2)
+        .build();
 
-    // 9. Summary
+    // ── Single job with 3 steps ───────────────────────────────────────────────
+    let job = JobBuilder::new()
+        .start(&step1)
+        .next(&step2)
+        .next(&step3)
+        .build();
+
+    job.run()?;
+
+    // ── Per-step metrics ──────────────────────────────────────────────────────
+    let step_names = [
+        ("csv-to-postgres", 1usize),
+        ("postgres-to-xml", 2),
+        ("xml-to-postgres-import", 3),
+    ];
+    for (name, idx) in &step_names {
+        let exec = job
+            .get_step_execution(name)
+            .expect("step must exist after job.run()");
+        let secs = exec.duration.unwrap_or_default().as_secs_f64();
+        eprintln!(
+            "[Step {}] Done — {} records in {:.1}s ({:.0} rec/s)",
+            idx,
+            exec.write_count,
+            secs,
+            exec.write_count as f64 / secs
+        );
+        if exec.read_error_count > 0 || exec.write_error_count > 0 {
+            eprintln!(
+                "[Step {}] WARNING: {} read errors, {} write errors skipped",
+                idx, exec.read_error_count, exec.write_error_count
+            );
+        }
+        eprintln!();
+    }
+
+    // ── Summary ───────────────────────────────────────────────────────────────
     let total_secs = t_total.elapsed().as_secs_f64();
     eprintln!("╔══════════════════════════════════════════════════════════╗");
     eprintln!("║  BENCHMARK SUMMARY                                       ║");

--- a/examples/database_processing.rs
+++ b/examples/database_processing.rs
@@ -6,7 +6,7 @@
 //! ## Features Demonstrated
 //! - Reading from database with pagination
 //! - Writing to database with batch inserts
-//! - Custom item binders for type-safe binding
+//! - Fluent column binding API for type-safe binding
 //! - Database to CSV/JSON export
 //! - CSV import to database
 //!
@@ -28,10 +28,10 @@ use spring_batch_rs::{
         csv::csv_writer::CsvItemWriterBuilder,
         json::json_writer::JsonItemWriterBuilder,
         logger::LoggerWriterBuilder,
-        rdbc::{DatabaseItemBinder, RdbcItemReaderBuilder, RdbcItemWriterBuilder},
+        rdbc::{RdbcItemReaderBuilder, RdbcItemWriterBuilder},
     },
 };
-use sqlx::{FromRow, Sqlite, SqlitePool, query_builder::Separated};
+use sqlx::{FromRow, SqlitePool};
 use std::env::temp_dir;
 
 // =============================================================================
@@ -54,30 +54,6 @@ struct Product {
     name: String,
     price: f64,
     stock: i32,
-}
-
-/// Binder for User records to SQLite.
-struct UserBinder;
-
-impl DatabaseItemBinder<User, Sqlite> for UserBinder {
-    fn bind(&self, item: &User, mut query_builder: Separated<Sqlite, &str>) {
-        query_builder.push_bind(item.id);
-        query_builder.push_bind(item.name.clone());
-        query_builder.push_bind(item.email.clone());
-        query_builder.push_bind(item.active);
-    }
-}
-
-/// Binder for Product records to SQLite.
-struct ProductBinder;
-
-impl DatabaseItemBinder<Product, Sqlite> for ProductBinder {
-    fn bind(&self, item: &Product, mut query_builder: Separated<Sqlite, &str>) {
-        query_builder.push_bind(item.id);
-        query_builder.push_bind(item.name.clone());
-        query_builder.push_bind(item.price);
-        query_builder.push_bind(item.stock);
-    }
 }
 
 /// Processor that marks all users as active.
@@ -276,15 +252,13 @@ id,name,price,stock
         .has_headers(true)
         .from_reader(csv_data.as_bytes());
 
-    let binder = ProductBinder;
     let writer = RdbcItemWriterBuilder::<Product>::new()
         .sqlite(pool)
         .table("products")
-        .add_column("id")
-        .add_column("name")
-        .add_column("price")
-        .add_column("stock")
-        .sqlite_binder(&binder)
+        .column("id", |p: &Product| p.id.into())
+        .column("name", |p: &Product| p.name.clone().into())
+        .column("price", |p: &Product| p.price.into())
+        .column("stock", |p: &Product| p.stock.into())
         .build_sqlite();
 
     let processor = PassThroughProcessor::<Product>::new();
@@ -337,15 +311,13 @@ fn example_transform_and_write(pool: &SqlitePool) -> Result<(), BatchError> {
         .query("SELECT id, name, email, active FROM users WHERE active = 0")
         .build_sqlite();
 
-    let binder = UserBinder;
     let writer = RdbcItemWriterBuilder::<User>::new()
         .sqlite(pool)
         .table("activated_users")
-        .add_column("id")
-        .add_column("name")
-        .add_column("email")
-        .add_column("active")
-        .sqlite_binder(&binder)
+        .column("id", |u: &User| u.id.into())
+        .column("name", |u: &User| u.name.clone().into())
+        .column("email", |u: &User| u.email.clone().into())
+        .column("active", |u: &User| u.active.into())
         .build_sqlite();
 
     let processor = ActivateUserProcessor;

--- a/src/item/rdbc/column_value.rs
+++ b/src/item/rdbc/column_value.rs
@@ -33,6 +33,12 @@ pub enum ColumnValue {
     Null,
 }
 
+impl From<i16> for ColumnValue {
+    fn from(v: i16) -> Self {
+        ColumnValue::Int(v as i64)
+    }
+}
+
 impl From<i32> for ColumnValue {
     fn from(v: i32) -> Self {
         ColumnValue::Int(v as i64)
@@ -93,6 +99,11 @@ impl<T: Into<ColumnValue>> From<Option<T>> for ColumnValue {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn should_convert_i16_to_int() {
+        assert!(matches!(ColumnValue::from(7i16), ColumnValue::Int(7)));
+    }
 
     #[test]
     fn should_convert_i32_to_int() {

--- a/src/item/rdbc/column_value.rs
+++ b/src/item/rdbc/column_value.rs
@@ -1,0 +1,172 @@
+//! Type-erased column value for RDBC item writers.
+
+/// A type-erased value that can be bound to a database column.
+///
+/// Used by RDBC item writers to carry field values from item extractor closures
+/// to database parameter binding at write time. This enum allows storing values
+/// of different types in a single collection without requiring static type dispatch.
+///
+/// # Examples
+///
+/// ```
+/// use spring_batch_rs::item::rdbc::ColumnValue;
+///
+/// let v: ColumnValue = 42i32.into();
+/// assert!(matches!(v, ColumnValue::Int(42)));
+///
+/// let v: ColumnValue = None::<i32>.into();
+/// assert!(matches!(v, ColumnValue::Null));
+/// ```
+#[derive(Clone, Debug, PartialEq)]
+pub enum ColumnValue {
+    /// Signed integer (covers i32, i64).
+    Int(i64),
+    /// Floating-point number (covers f32, f64).
+    Float(f64),
+    /// UTF-8 text (covers &str, String).
+    Text(String),
+    /// Boolean value.
+    Bool(bool),
+    /// Raw bytes.
+    Bytes(Vec<u8>),
+    /// SQL NULL — produced by Option::None.
+    Null,
+}
+
+impl From<i32> for ColumnValue {
+    fn from(v: i32) -> Self {
+        ColumnValue::Int(v as i64)
+    }
+}
+
+impl From<i64> for ColumnValue {
+    fn from(v: i64) -> Self {
+        ColumnValue::Int(v)
+    }
+}
+
+impl From<f32> for ColumnValue {
+    fn from(v: f32) -> Self {
+        ColumnValue::Float(v as f64)
+    }
+}
+
+impl From<f64> for ColumnValue {
+    fn from(v: f64) -> Self {
+        ColumnValue::Float(v)
+    }
+}
+
+impl From<bool> for ColumnValue {
+    fn from(v: bool) -> Self {
+        ColumnValue::Bool(v)
+    }
+}
+
+impl From<&str> for ColumnValue {
+    fn from(v: &str) -> Self {
+        ColumnValue::Text(v.to_string())
+    }
+}
+
+impl From<String> for ColumnValue {
+    fn from(v: String) -> Self {
+        ColumnValue::Text(v)
+    }
+}
+
+impl From<Vec<u8>> for ColumnValue {
+    fn from(v: Vec<u8>) -> Self {
+        ColumnValue::Bytes(v)
+    }
+}
+
+impl<T: Into<ColumnValue>> From<Option<T>> for ColumnValue {
+    fn from(v: Option<T>) -> Self {
+        match v {
+            Some(inner) => inner.into(),
+            None => ColumnValue::Null,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn should_convert_i32_to_int() {
+        assert!(matches!(ColumnValue::from(42i32), ColumnValue::Int(42)));
+    }
+
+    #[test]
+    fn should_convert_i64_to_int() {
+        assert!(matches!(ColumnValue::from(100i64), ColumnValue::Int(100)));
+    }
+
+    #[test]
+    fn should_convert_f32_to_float() {
+        let v = ColumnValue::from(1.5f32);
+        assert!(matches!(v, ColumnValue::Float(_)));
+        if let ColumnValue::Float(f) = v {
+            assert!((f - 1.5f64).abs() < 1e-5, "f32 should be widened to f64");
+        }
+    }
+
+    #[test]
+    fn should_convert_f64_to_float() {
+        assert!(matches!(ColumnValue::from(3.14f64), ColumnValue::Float(_)));
+    }
+
+    #[test]
+    fn should_convert_bool_to_bool() {
+        assert!(matches!(ColumnValue::from(true), ColumnValue::Bool(true)));
+        assert!(matches!(ColumnValue::from(false), ColumnValue::Bool(false)));
+    }
+
+    #[test]
+    fn should_convert_str_to_text() {
+        assert!(matches!(ColumnValue::from("hello"), ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_string_to_text() {
+        assert!(matches!(
+            ColumnValue::from("world".to_string()),
+            ColumnValue::Text(_)
+        ));
+    }
+
+    #[test]
+    fn should_convert_bytes_to_bytes() {
+        let v = ColumnValue::from(vec![1u8, 2, 3]);
+        assert!(matches!(v, ColumnValue::Bytes(_)));
+    }
+
+    #[test]
+    fn should_convert_some_i32_to_int() {
+        assert!(matches!(
+            ColumnValue::from(Some(7i32)),
+            ColumnValue::Int(7)
+        ));
+    }
+
+    #[test]
+    fn should_convert_none_i32_to_null() {
+        assert!(matches!(ColumnValue::from(None::<i32>), ColumnValue::Null));
+    }
+
+    #[test]
+    fn should_convert_some_string_to_text() {
+        let v = ColumnValue::from(Some("abc".to_string()));
+        assert!(matches!(v, ColumnValue::Text(_)));
+    }
+
+    #[test]
+    fn should_convert_none_string_to_null() {
+        assert!(matches!(
+            ColumnValue::from(None::<String>),
+            ColumnValue::Null
+        ));
+    }
+}

--- a/src/item/rdbc/column_value.rs
+++ b/src/item/rdbc/column_value.rs
@@ -145,10 +145,7 @@ mod tests {
 
     #[test]
     fn should_convert_some_i32_to_int() {
-        assert!(matches!(
-            ColumnValue::from(Some(7i32)),
-            ColumnValue::Int(7)
-        ));
+        assert!(matches!(ColumnValue::from(Some(7i32)), ColumnValue::Int(7)));
     }
 
     #[test]

--- a/src/item/rdbc/mod.rs
+++ b/src/item/rdbc/mod.rs
@@ -1,5 +1,8 @@
 use sqlx::{Database, query_builder::Separated};
 
+/// Type-erased column value for item writers.
+mod column_value;
+
 /// Fluent SQL SELECT builder for RDBC item readers.
 mod select_builder;
 
@@ -137,6 +140,7 @@ pub use sqlite_reader::SqliteRdbcItemReader;
 pub use sqlite_writer::SqliteItemWriter;
 
 // Re-export unified builder types (recommended API)
+pub use column_value::ColumnValue;
 pub use database_type::DatabaseType;
 pub use select_builder::SelectBuilder;
 pub use unified_reader_builder::RdbcItemReaderBuilder;

--- a/src/item/rdbc/mod.rs
+++ b/src/item/rdbc/mod.rs
@@ -1,7 +1,7 @@
 use sqlx::{Database, query_builder::Separated};
 
 /// Fluent SQL SELECT builder for RDBC item readers.
-pub mod select_builder;
+mod select_builder;
 
 /// Common utilities for database item writers.
 mod writer_common;

--- a/src/item/rdbc/mod.rs
+++ b/src/item/rdbc/mod.rs
@@ -1,5 +1,3 @@
-use sqlx::{Database, query_builder::Separated};
-
 /// Type-erased column value for item writers.
 mod column_value;
 
@@ -38,98 +36,6 @@ pub mod mysql_writer;
 
 /// SQLite-specific writer implementation.
 pub mod sqlite_writer;
-
-/// Trait for binding item data to database query parameters.
-///
-/// This trait is generic over the database type, allowing it to work with
-/// PostgreSQL, MySQL, SQLite, and other databases supported by SQLx.
-/// This provides a unified interface for database-specific item writers.
-///
-/// # Type Parameters
-///
-/// * `O` - The item type to bind
-/// * `DB` - The SQLx database type (e.g., `Postgres`, `MySql`, `Sqlite`)
-///
-/// # Examples
-///
-/// ## PostgreSQL Implementation
-/// ```no_run
-/// use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-/// use sqlx::{query_builder::Separated, Postgres};
-/// use serde::Serialize;
-///
-/// #[derive(Clone, Serialize)]
-/// struct User {
-///     id: i32,
-///     name: String,
-/// }
-///
-/// struct UserBinder;
-/// impl DatabaseItemBinder<User, Postgres> for UserBinder {
-///     fn bind(&self, item: &User, mut query_builder: Separated<Postgres, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///     }
-/// }
-/// ```
-///
-/// ## MySQL Implementation
-/// ```no_run
-/// use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-/// use sqlx::{query_builder::Separated, MySql};
-/// use serde::Serialize;
-///
-/// #[derive(Clone, Serialize)]
-/// struct Product {
-///     id: i32,
-///     name: String,
-///     price: f64,
-/// }
-///
-/// struct ProductBinder;
-/// impl DatabaseItemBinder<Product, MySql> for ProductBinder {
-///     fn bind(&self, item: &Product, mut query_builder: Separated<MySql, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///         // In real usage: query_builder.push_bind(item.price);
-///     }
-/// }
-/// ```
-///
-/// ## SQLite Implementation
-/// ```no_run
-/// use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-/// use sqlx::{query_builder::Separated, Sqlite};
-/// use serde::Serialize;
-///
-/// #[derive(Clone, Serialize)]
-/// struct Task {
-///     id: i32,
-///     title: String,
-///     completed: bool,
-/// }
-///
-/// struct TaskBinder;
-/// impl DatabaseItemBinder<Task, Sqlite> for TaskBinder {
-///     fn bind(&self, item: &Task, mut query_builder: Separated<Sqlite, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.title);
-///         // In real usage: query_builder.push_bind(item.completed);
-///     }
-/// }
-/// ```
-pub trait DatabaseItemBinder<O, DB: Database> {
-    /// Binds the properties of an item to a separated query builder.
-    ///
-    /// # Arguments
-    ///
-    /// * `item` - The item whose properties should be bound.
-    /// * `query_builder` - The separated query builder to bind parameters to.
-    fn bind(&self, item: &O, query_builder: Separated<DB, &str>);
-}
 
 // Re-export database-specific reader and writer types (for direct usage)
 pub use mysql_reader::MySqlRdbcItemReader;

--- a/src/item/rdbc/mod.rs
+++ b/src/item/rdbc/mod.rs
@@ -1,5 +1,8 @@
 use sqlx::{Database, query_builder::Separated};
 
+/// Fluent SQL SELECT builder for RDBC item readers.
+pub mod select_builder;
+
 /// Common utilities for database item writers.
 mod writer_common;
 
@@ -135,5 +138,6 @@ pub use sqlite_writer::SqliteItemWriter;
 
 // Re-export unified builder types (recommended API)
 pub use database_type::DatabaseType;
+pub use select_builder::SelectBuilder;
 pub use unified_reader_builder::RdbcItemReaderBuilder;
 pub use unified_writer_builder::RdbcItemWriterBuilder;

--- a/src/item/rdbc/mysql_reader.rs
+++ b/src/item/rdbc/mysql_reader.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, RefCell};
 
-use sqlx::{Execute, FromRow, MySql, Pool, QueryBuilder, mysql::MySqlRow};
+use sqlx::{FromRow, MySql, Pool, QueryBuilder, mysql::MySqlRow};
 
 use super::reader_common::{calculate_page_index, should_load_page};
 use crate::BatchError;
@@ -67,10 +67,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                let last = self.last_cursor.borrow();
-                if let Some(ref cursor_val) = *last {
-                    let escaped = cursor_val.replace('\'', "''");
-                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
+                {
+                    let last = self.last_cursor.borrow();
+                    if let Some(ref cursor_val) = *last {
+                        query_builder.push(format!(" WHERE {} > ", col));
+                        query_builder.push_bind(cursor_val.clone());
+                    }
                 }
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
@@ -78,19 +80,17 @@ where
             }
         }
 
-        let query = query_builder.build();
-
+        let query = query_builder.build_query_as::<I>();
         let items = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                sqlx::query_as::<_, I>(query.sql())
+                query
                     .fetch_all(&self.pool)
                     .await
                     .map_err(|e| BatchError::ItemReader(e.to_string()))
             })
         })?;
 
-        self.buffer.borrow_mut().clear();
-        self.buffer.borrow_mut().extend(items);
+        *self.buffer.borrow_mut() = items;
         Ok(())
     }
 }

--- a/src/item/rdbc/mysql_reader.rs
+++ b/src/item/rdbc/mysql_reader.rs
@@ -67,13 +67,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                {
-                    let last = self.last_cursor.borrow();
-                    if let Some(ref cursor_val) = *last {
-                        query_builder.push(format!(" WHERE {} > ", col));
-                        query_builder.push_bind(cursor_val.clone());
-                    }
+                let last = self.last_cursor.borrow();
+                if let Some(ref cursor_val) = *last {
+                    let escaped = cursor_val.replace('\'', "''");
+                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
                 }
+                drop(last);
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
                 query_builder.push(format!(" LIMIT {} OFFSET {}", page_size, self.offset.get()));

--- a/src/item/rdbc/mysql_reader.rs
+++ b/src/item/rdbc/mysql_reader.rs
@@ -6,20 +6,14 @@ use super::reader_common::{calculate_page_index, should_load_page};
 use crate::BatchError;
 use crate::core::item::{ItemReader, ItemReaderResult};
 
-/// MySQL RDBC Item Reader for batch processing
-///
-/// # Construction
-///
-/// This reader can only be created through `RdbcItemReaderBuilder`.
-/// Direct construction is not available to ensure proper configuration.
 /// MySQL RDBC Item Reader for batch processing.
 ///
 /// Supports LIMIT/OFFSET pagination (default) and keyset pagination
-/// (enabled via [`RdbcItemReaderBuilder::with_keyset`]).
+/// (enabled via [`RdbcItemReaderBuilder::with_keyset`](crate::item::rdbc::RdbcItemReaderBuilder::with_keyset)).
 ///
 /// # Construction
 ///
-/// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
+/// Prefer [`RdbcItemReaderBuilder`](crate::item::rdbc::RdbcItemReaderBuilder) for ergonomic construction.
 pub struct MySqlRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
@@ -39,10 +33,10 @@ impl<I> MySqlRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
 {
-    /// Creates a new MySqlRdbcItemReader with the specified parameters
+    /// Creates a new `MySqlRdbcItemReader` with the specified parameters.
     ///
-    /// This constructor is only accessible within the crate to enforce the use
-    /// of `RdbcItemReaderBuilder` for creating reader instances.
+    /// Prefer [`RdbcItemReaderBuilder`](crate::item::rdbc::RdbcItemReaderBuilder) for a more
+    /// ergonomic construction API.
     #[allow(clippy::type_complexity)]
     pub fn new(
         pool: Pool<MySql>,
@@ -63,11 +57,6 @@ where
         }
     }
 
-    /// Reads a page of data from the database and stores it in the internal buffer.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`BatchError::ItemReader`] if the database query fails.
     /// Fetches the next page from the database into the internal buffer.
     ///
     /// # Errors
@@ -103,6 +92,29 @@ where
         self.buffer.borrow_mut().clear();
         self.buffer.borrow_mut().extend(items);
         Ok(())
+    }
+}
+
+impl<I> ItemReader<I> for MySqlRdbcItemReader<I>
+where
+    for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
+{
+    fn read(&self) -> ItemReaderResult<I> {
+        let index = calculate_page_index(self.offset.get(), self.page_size);
+
+        if should_load_page(index) {
+            self.read_page()?;
+        }
+
+        let result = self.buffer.borrow().get(index as usize).cloned();
+
+        if let (Some(item), Some(key_fn)) = (&result, &self.keyset_key) {
+            *self.last_cursor.borrow_mut() = Some(key_fn(item));
+        }
+
+        self.offset.set(self.offset.get() + 1);
+
+        Ok(result)
     }
 }
 
@@ -167,28 +179,5 @@ mod tests {
             reader.last_cursor.borrow().is_none(),
             "cursor must start as None before first read"
         );
-    }
-}
-
-impl<I> ItemReader<I> for MySqlRdbcItemReader<I>
-where
-    for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
-{
-    fn read(&self) -> ItemReaderResult<I> {
-        let index = calculate_page_index(self.offset.get(), self.page_size);
-
-        if should_load_page(index) {
-            self.read_page()?;
-        }
-
-        let result = self.buffer.borrow().get(index as usize).cloned();
-
-        if let (Some(item), Some(key_fn)) = (&result, &self.keyset_key) {
-            *self.last_cursor.borrow_mut() = Some(key_fn(item));
-        }
-
-        self.offset.set(self.offset.get() + 1);
-
-        Ok(result)
     }
 }

--- a/src/item/rdbc/mysql_reader.rs
+++ b/src/item/rdbc/mysql_reader.rs
@@ -20,12 +20,12 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 /// # Construction
 ///
 /// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
-pub struct MySqlRdbcItemReader<'a, I>
+pub struct MySqlRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
 {
     pub(crate) pool: Pool<MySql>,
-    pub(crate) query: &'a str,
+    pub(crate) query: String,
     pub(crate) page_size: Option<i32>,
     pub(crate) offset: Cell<i32>,
     pub(crate) buffer: RefCell<Vec<I>>,
@@ -35,7 +35,7 @@ where
     pub(crate) last_cursor: RefCell<Option<String>>,
 }
 
-impl<'a, I> MySqlRdbcItemReader<'a, I>
+impl<I> MySqlRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
 {
@@ -46,7 +46,7 @@ where
     #[allow(clippy::type_complexity)]
     pub fn new(
         pool: Pool<MySql>,
-        query: &'a str,
+        query: String,
         page_size: Option<i32>,
         keyset_column: Option<String>,
         keyset_key: Option<Box<dyn Fn(&I) -> String>>,
@@ -74,7 +74,7 @@ where
     ///
     /// Returns [`BatchError::ItemReader`] if the query fails.
     fn read_page(&self) -> Result<(), BatchError> {
-        let mut query_builder = QueryBuilder::<MySql>::new(self.query);
+        let mut query_builder = QueryBuilder::<MySql>::new(&self.query);
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
@@ -120,7 +120,7 @@ mod tests {
         }
     }
 
-    fn reader_with_keyset(keyset: bool) -> MySqlRdbcItemReader<'static, Dummy> {
+    fn reader_with_keyset(keyset: bool) -> MySqlRdbcItemReader<Dummy> {
         let pool = MySqlPool::connect_lazy("mysql://root:root@localhost/test")
             .expect("lazy pool creation should not fail");
         let (col, key): (Option<String>, Option<Box<dyn Fn(&Dummy) -> String>>) = if keyset {
@@ -131,7 +131,7 @@ mod tests {
         } else {
             (None, None)
         };
-        MySqlRdbcItemReader::new(pool, "SELECT 1", Some(10), col, key)
+        MySqlRdbcItemReader::new(pool, "SELECT 1".to_string(), Some(10), col, key)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -170,7 +170,7 @@ mod tests {
     }
 }
 
-impl<I> ItemReader<I> for MySqlRdbcItemReader<'_, I>
+impl<I> ItemReader<I> for MySqlRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, MySqlRow> + Send + Unpin + Clone,
 {

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -105,53 +105,53 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
             .map(|(n, _)| n.as_str())
             .collect();
 
-        let mut query_builder = QueryBuilder::new("INSERT INTO ");
-        query_builder.push(table);
-        query_builder.push(" (");
-        query_builder.push(col_names.join(","));
-        query_builder.push(") ");
-
+        let col_list = col_names.join(",");
         let max_items = max_items_per_batch(self.column_bindings.len());
-        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
-        let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |mut b, item| {
-            for (_, extractor) in &self.column_bindings {
-                match extractor(item) {
-                    ColumnValue::Int(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Float(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Text(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bool(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bytes(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Null => {
-                        b.push_bind(Option::<String>::None);
+        for chunk in items.chunks(max_items) {
+            let mut query_builder = QueryBuilder::new("INSERT INTO ");
+            query_builder.push(table);
+            query_builder.push(" (");
+            query_builder.push(&col_list);
+            query_builder.push(") ");
+
+            query_builder.push_values(chunk.iter(), |mut b, item| {
+                for (_, extractor) in &self.column_bindings {
+                    match extractor(item) {
+                        ColumnValue::Int(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Float(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Text(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bool(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bytes(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Null => {
+                            b.push_bind(Option::<String>::None);
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "MySQL");
-                Ok(())
+            if let Err(e) = result {
+                return Err(create_write_error(table, "MySQL", e));
             }
-            Err(e) => Err(create_write_error(table, "MySQL", e)),
         }
+
+        log_write_success(items.len(), table, "MySQL");
+        Ok(())
     }
 }
 

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sqlx::{MySql, Pool, QueryBuilder};
 
 use crate::core::item::{ItemWriter, ItemWriterResult};
-use crate::item::rdbc::DatabaseItemBinder;
+use crate::item::rdbc::ColumnValue;
 
 use super::writer_common::{
     create_write_error, log_write_success, max_items_per_batch, validate_config,
@@ -10,169 +10,147 @@ use super::writer_common::{
 
 /// A writer for inserting items into a MySQL database using SQLx.
 ///
-/// This writer provides an implementation of the `ItemWriter` trait for MySQL operations.
-/// It supports batch inserting items into a specified table with the provided columns.
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
 ///
-/// # MySQL-Specific Features
+/// # Construction
 ///
-/// - Supports MySQL's data types and character sets
-/// - Handles MySQL's AUTO_INCREMENT for auto-incrementing columns
-/// - Supports MySQL's INSERT ... ON DUPLICATE KEY UPDATE operations
-/// - Leverages MySQL's efficient bulk insert capabilities
-/// - Compatible with MySQL's connection pooling and prepared statements
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use spring_batch_rs::core::item::ItemWriter;
-/// use sqlx::{MySqlPool, query_builder::Separated, MySql};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::MySqlPool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
-/// struct Product {
-///     id: i32,
-///     name: String,
-///     price: f64,
-/// }
-///
-/// struct ProductBinder;
-/// impl DatabaseItemBinder<Product, MySql> for ProductBinder {
-///     fn bind(&self, item: &Product, mut query_builder: Separated<MySql, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///         // In real usage: query_builder.push_bind(item.price);
-///     }
-/// }
+/// struct Product { id: i32, name: String, price: f64 }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
-/// let binder = ProductBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<Product>::new()
 ///     .mysql(&pool)
 ///     .table("products")
-///     .add_column("id")
-///     .add_column("name")
-///     .add_column("price")
-///     .mysql_binder(&binder)
+///     .column("id", |p: &Product| p.id.into())
+///     .column("name", |p: &Product| p.name.as_str().into())
+///     .column("price", |p: &Product| p.price.into())
 ///     .build_mysql();
-///
-/// let products = vec![
-///     Product { id: 1, name: "Laptop".to_string(), price: 999.99 },
-///     Product { id: 2, name: "Mouse".to_string(), price: 29.99 },
-/// ];
-///
-/// writer.write(&products)?;
 /// # Ok(())
 /// # }
 /// ```
-pub struct MySqlItemWriter<'a, O> {
-    pub(crate) pool: Option<&'a Pool<MySql>>,
-    pub(crate) table: Option<&'a str>,
-    pub(crate) columns: Vec<&'a str>,
-    pub(crate) item_binder: Option<&'a dyn DatabaseItemBinder<O, MySql>>,
+pub struct MySqlItemWriter<O> {
+    pub(crate) pool: Option<sqlx::Pool<MySql>>,
+    pub(crate) table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
 }
 
-impl<'a, O> MySqlItemWriter<'a, O> {
+impl<O> MySqlItemWriter<O> {
     /// Creates a new `MySqlItemWriter` with default configuration.
-    pub(crate) fn new() -> Self {
+    pub fn new() -> Self {
         Self {
             pool: None,
             table: None,
-            columns: Vec::new(),
-            item_binder: None,
+            column_bindings: Vec::new(),
         }
     }
 
     /// Sets the database connection pool for the writer.
-    pub(crate) fn pool(mut self, pool: &'a Pool<MySql>) -> Self {
-        self.pool = Some(pool);
+    pub fn pool(mut self, pool: &Pool<MySql>) -> Self {
+        self.pool = Some(pool.clone());
         self
     }
 
     /// Sets the table name for the writer.
-    pub(crate) fn table(mut self, table: &'a str) -> Self {
-        self.table = Some(table);
+    pub fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
         self
     }
 
-    /// Adds a column to the writer.
-    pub(crate) fn add_column(mut self, column: &'a str) -> Self {
-        self.columns.push(column);
-        self
-    }
-
-    /// Sets the item binder for the writer.
-    pub(crate) fn item_binder(mut self, item_binder: &'a dyn DatabaseItemBinder<O, MySql>) -> Self {
-        self.item_binder = Some(item_binder);
+    /// Adds a column binding to the writer.
+    pub fn add_column_binding(
+        mut self,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
+    ) -> Self {
+        self.column_bindings.push((name, extractor));
         self
     }
 }
 
-impl<'a, O> Default for MySqlItemWriter<'a, O> {
+impl<O> Default for MySqlItemWriter<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
+impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
     fn write(&self, items: &[O]) -> ItemWriterResult {
         if items.is_empty() {
             return Ok(());
         }
 
-        if self.columns.is_empty() {
-            return Err(crate::BatchError::ItemWriter(
-                "No columns specified for database write".to_string(),
-            ));
-        }
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
 
-        let pool = self.pool.ok_or_else(|| {
-            crate::BatchError::ItemWriter("Database pool not configured".to_string())
-        })?;
-        let table = self.table.ok_or_else(|| {
-            crate::BatchError::ItemWriter("Table name not configured".to_string())
-        })?;
+        let col_names: Vec<&str> = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
 
-        // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
         query_builder.push(table);
         query_builder.push(" (");
-        query_builder.push(self.columns.join(","));
+        query_builder.push(col_names.join(","));
         query_builder.push(") ");
 
-        // Calculate max items per batch and add values
-        let max_items = max_items_per_batch(self.columns.len());
-        let items_to_write = items.iter().take(max_items);
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
         let items_count = items_to_write.len();
 
-        // TODO: TASK 4 — bind items using new API
-        // query_builder.push_values(items_to_write, |b, item| {
-        //     item_binder.bind(item, b);
-        // });
-
-        // Return early for now to let tests compile
-        return Err(crate::BatchError::ItemWriter(
-            "TODO: implement new binding API".to_string(),
-        ));
-
-        // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        #[allow(unreachable_code)]
-        {
-            let query = query_builder.build();
-            let result = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-            });
-
-            match result {
-                Ok(_) => {
-                    log_write_success(items_count, table, "MySQL");
-                    Ok(())
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Float(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Text(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bool(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bytes(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Null => {
+                        b.push_bind(Option::<String>::None);
+                    }
                 }
-                Err(e) => Err(create_write_error(table, "MySQL", e)),
             }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "MySQL");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "MySQL", e)),
         }
     }
 }
@@ -180,90 +158,54 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::item::ItemWriter;
+    use crate::item::rdbc::ColumnValue;
 
     #[test]
-    fn test_new_creates_default_writer() {
+    fn should_start_with_empty_state() {
         let writer = MySqlItemWriter::<String>::new();
-
         assert!(writer.pool.is_none());
         assert!(writer.table.is_none());
-        assert!(writer.columns.is_empty());
-        assert!(writer.item_binder.is_none());
+        assert!(writer.column_bindings.is_empty());
     }
 
     #[test]
-    fn test_builder_pattern_configuration() {
+    fn should_store_column_bindings_in_order() {
         let writer = MySqlItemWriter::<String>::new()
-            .table("products")
-            .add_column("id")
-            .add_column("name")
-            .add_column("price");
-
-        assert_eq!(writer.table, Some("products"));
-        assert_eq!(writer.columns, vec!["id", "name", "price"]);
+            .add_column_binding("x".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("y".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["x", "y"]);
     }
 
     #[test]
-    fn test_write_empty_items() {
-        use crate::item::rdbc::DatabaseItemBinder;
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, MySql> for DummyBinder {
-            fn bind(&self, _item: &String, _query_builder: Separated<MySql, &str>) {}
-        }
-
-        let binder = DummyBinder;
-        let writer = MySqlItemWriter::<String>::new()
-            .table("test")
-            .add_column("value")
-            .item_binder(&binder);
-
-        let result = writer.write(&[]);
-        assert!(result.is_ok());
+    fn should_return_ok_for_empty_items() {
+        let writer = MySqlItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
     }
 
     #[test]
-    fn should_return_error_when_columns_missing_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, MySql> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<MySql, &str>) {}
-        }
-        let binder = DummyBinder;
-        let writer = MySqlItemWriter::<String>::new()
-            .table("t")
-            .item_binder(&binder); // no columns
-
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = MySqlItemWriter::<String>::new().table("t");
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing columns");
-        match result.unwrap_err() {
+        match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
     }
 
     #[test]
-    fn should_return_error_when_pool_not_configured_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, MySql> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<MySql, &str>) {}
-        }
-        let binder = DummyBinder;
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
         let writer = MySqlItemWriter::<String>::new()
             .table("t")
-            .add_column("v")
-            .item_binder(&binder); // no pool
-
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing pool");
-        match result.unwrap_err() {
+        match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -123,9 +123,13 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
             return Ok(());
         }
 
+        // TODO: TASK 4 — update validate_config to new signature
         // Validate configuration
-        let (pool, table, item_binder) =
-            validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        // let (pool, table, item_binder) =
+        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+
+        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
+        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
 
         // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
@@ -139,22 +143,29 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
         let items_to_write = items.iter().take(max_items);
         let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |b, item| {
-            item_binder.bind(item, b);
-        });
+        // TODO: TASK 4 — bind items using new API
+        // query_builder.push_values(items_to_write, |b, item| {
+        //     item_binder.bind(item, b);
+        // });
+
+        // Return early for now to let tests compile
+        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
 
         // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+        #[allow(unreachable_code)]
+        {
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "MySQL");
-                Ok(())
+            match result {
+                Ok(_) => {
+                    log_write_success(items_count, table, "MySQL");
+                    Ok(())
+                }
+                Err(e) => Err(create_write_error(table, "MySQL", e)),
             }
-            Err(e) => Err(create_write_error(table, "MySQL", e)),
         }
     }
 }

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -50,7 +50,7 @@ pub struct MySqlItemWriter<O> {
 
 impl<O> MySqlItemWriter<O> {
     /// Creates a new `MySqlItemWriter` with default configuration.
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             pool: None,
             table: None,
@@ -59,19 +59,19 @@ impl<O> MySqlItemWriter<O> {
     }
 
     /// Sets the database connection pool for the writer.
-    pub fn pool(mut self, pool: &Pool<MySql>) -> Self {
+    pub(crate) fn pool(mut self, pool: &Pool<MySql>) -> Self {
         self.pool = Some(pool.clone());
         self
     }
 
     /// Sets the table name for the writer.
-    pub fn table(mut self, table: &str) -> Self {
+    pub(crate) fn table(mut self, table: &str) -> Self {
         self.table = Some(table.to_string());
         self
     }
 
     /// Adds a column binding to the writer.
-    pub fn add_column_binding(
+    pub(crate) fn add_column_binding(
         mut self,
         name: String,
         extractor: Box<dyn Fn(&O) -> ColumnValue>,

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -123,13 +123,18 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
             return Ok(());
         }
 
-        // TODO: TASK 4 — update validate_config to new signature
-        // Validate configuration
-        // let (pool, table, item_binder) =
-        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        if self.columns.is_empty() {
+            return Err(crate::BatchError::ItemWriter(
+                "No columns specified for database write".to_string(),
+            ));
+        }
 
-        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
-        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
+        let pool = self.pool.ok_or_else(|| {
+            crate::BatchError::ItemWriter("Database pool not configured".to_string())
+        })?;
+        let table = self.table.ok_or_else(|| {
+            crate::BatchError::ItemWriter("Table name not configured".to_string())
+        })?;
 
         // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
@@ -149,7 +154,9 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<'_, O> {
         // });
 
         // Return early for now to let tests compile
-        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
+        return Err(crate::BatchError::ItemWriter(
+            "TODO: implement new binding API".to_string(),
+        ));
 
         // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
         #[allow(unreachable_code)]

--- a/src/item/rdbc/postgres_reader.rs
+++ b/src/item/rdbc/postgres_reader.rs
@@ -93,13 +93,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                {
-                    let last = self.last_cursor.borrow();
-                    if let Some(ref cursor_val) = *last {
-                        query_builder.push(format!(" WHERE {} > ", col));
-                        query_builder.push_bind(cursor_val.clone());
-                    }
+                let last = self.last_cursor.borrow();
+                if let Some(ref cursor_val) = *last {
+                    let escaped = cursor_val.replace('\'', "''");
+                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
                 }
+                drop(last);
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
                 query_builder.push(format!(" LIMIT {} OFFSET {}", page_size, self.offset.get()));

--- a/src/item/rdbc/postgres_reader.rs
+++ b/src/item/rdbc/postgres_reader.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, RefCell};
 
-use sqlx::{Execute, FromRow, Pool, Postgres, QueryBuilder, postgres::PgRow};
+use sqlx::{FromRow, Pool, Postgres, QueryBuilder, postgres::PgRow};
 
 use super::reader_common::{calculate_page_index, should_load_page};
 use crate::BatchError;
@@ -93,11 +93,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                let last = self.last_cursor.borrow();
-                if let Some(ref cursor_val) = *last {
-                    // Escape single quotes to prevent SQL injection from cursor values.
-                    let escaped = cursor_val.replace('\'', "''");
-                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
+                {
+                    let last = self.last_cursor.borrow();
+                    if let Some(ref cursor_val) = *last {
+                        query_builder.push(format!(" WHERE {} > ", col));
+                        query_builder.push_bind(cursor_val.clone());
+                    }
                 }
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
@@ -105,19 +106,17 @@ where
             }
         }
 
-        let query = query_builder.build();
-
+        let query = query_builder.build_query_as::<I>();
         let items = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                sqlx::query_as::<_, I>(query.sql())
+                query
                     .fetch_all(&self.pool)
                     .await
                     .map_err(|e| BatchError::ItemReader(e.to_string()))
             })
         })?;
 
-        self.buffer.borrow_mut().clear();
-        self.buffer.borrow_mut().extend(items);
+        *self.buffer.borrow_mut() = items;
         Ok(())
     }
 }

--- a/src/item/rdbc/postgres_reader.rs
+++ b/src/item/rdbc/postgres_reader.rs
@@ -21,12 +21,12 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 /// # Construction
 ///
 /// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
-pub struct PostgresRdbcItemReader<'a, I>
+pub struct PostgresRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
 {
     pub(crate) pool: Pool<Postgres>,
-    pub(crate) query: &'a str,
+    pub(crate) query: String,
     pub(crate) page_size: Option<i32>,
     pub(crate) offset: Cell<i32>,
     pub(crate) buffer: RefCell<Vec<I>>,
@@ -39,7 +39,7 @@ where
     pub(crate) last_cursor: RefCell<Option<String>>,
 }
 
-impl<'a, I> PostgresRdbcItemReader<'a, I>
+impl<I> PostgresRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
 {
@@ -60,7 +60,7 @@ where
     #[allow(clippy::type_complexity)]
     pub fn new(
         pool: Pool<Postgres>,
-        query: &'a str,
+        query: String,
         page_size: Option<i32>,
         keyset_column: Option<String>,
         keyset_key: Option<Box<dyn Fn(&I) -> String>>,
@@ -86,7 +86,7 @@ where
     ///
     /// Returns [`BatchError::ItemReader`] if the query fails.
     fn read_page(&self) -> Result<(), BatchError> {
-        let mut query_builder = QueryBuilder::<Postgres>::new(self.query);
+        let mut query_builder = QueryBuilder::<Postgres>::new(&self.query);
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
@@ -142,7 +142,7 @@ mod tests {
         }
     }
 
-    fn reader_with_keyset(keyset: bool) -> PostgresRdbcItemReader<'static, Dummy> {
+    fn reader_with_keyset(keyset: bool) -> PostgresRdbcItemReader<Dummy> {
         let pool = PgPool::connect_lazy("postgres://postgres:postgres@localhost/test")
             .expect("lazy pool creation should not fail");
         let (col, key): (Option<String>, Option<Box<dyn Fn(&Dummy) -> String>>) = if keyset {
@@ -153,7 +153,7 @@ mod tests {
         } else {
             (None, None)
         };
-        PostgresRdbcItemReader::new(pool, "SELECT 1", Some(10), col, key)
+        PostgresRdbcItemReader::new(pool, "SELECT 1".to_string(), Some(10), col, key)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -192,7 +192,7 @@ mod tests {
     }
 }
 
-impl<I> ItemReader<I> for PostgresRdbcItemReader<'_, I>
+impl<I> ItemReader<I> for PostgresRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
 {

--- a/src/item/rdbc/postgres_reader.rs
+++ b/src/item/rdbc/postgres_reader.rs
@@ -12,7 +12,8 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 ///
 /// - **LIMIT/OFFSET** (default): simple but degrades at large offsets — use for small datasets.
 /// - **Keyset pagination** (recommended for large datasets): uses `WHERE col > :last ORDER BY col LIMIT n`,
-///   O(log n) per page regardless of dataset size. Enable with [`RdbcItemReaderBuilder::with_keyset`].
+///   O(log n) per page regardless of dataset size. Enable with
+///   [`RdbcItemReaderBuilder::with_keyset`](crate::item::rdbc::RdbcItemReaderBuilder::with_keyset).
 ///
 /// # Type Parameters
 ///
@@ -20,7 +21,7 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 ///
 /// # Construction
 ///
-/// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
+/// Prefer [`RdbcItemReaderBuilder`](crate::item::rdbc::RdbcItemReaderBuilder) for ergonomic construction.
 pub struct PostgresRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
@@ -43,16 +44,18 @@ impl<I> PostgresRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
 {
-    /// Creates a new PostgresRdbcItemReader with the specified parameters
+    /// Creates a new `PostgresRdbcItemReader` with the specified parameters.
     ///
-    /// This constructor is only accessible within the crate to enforce the use
-    /// of `RdbcItemReaderBuilder` for creating reader instances.
+    /// Prefer [`RdbcItemReaderBuilder`](crate::item::rdbc::RdbcItemReaderBuilder) for a more
+    /// ergonomic construction API.
     ///
     /// # Arguments
     ///
     /// * `pool` - PostgreSQL connection pool for database operations
     /// * `query` - SQL query to execute (without LIMIT/OFFSET)
     /// * `page_size` - Optional page size for pagination. None means read all at once.
+    /// * `keyset_column` - Optional column name for keyset pagination.
+    /// * `keyset_key` - Optional closure to extract the cursor value from an item.
     ///
     /// # Returns
     ///
@@ -79,7 +82,7 @@ where
 
     /// Fetches the next page from the database into the internal buffer.
     ///
-    /// Uses keyset pagination when [`keyset_column`] is set, otherwise falls back
+    /// Uses keyset pagination when `keyset_column` is set, otherwise falls back
     /// to LIMIT/OFFSET.
     ///
     /// # Errors
@@ -119,15 +122,68 @@ where
     }
 }
 
-/// Implementation of ItemReader trait for PostgresRdbcItemReader.
-///
-/// This implementation provides a way to read items from a PostgreSQL database
-/// with support for pagination. It uses an internal buffer to store the results
-/// of database queries and keeps track of the current offset to determine when
-/// a new page of data needs to be fetched.
-///
-/// The implementation handles both paginated and non-paginated reading modes
-/// transparently, making it suitable for various batch processing scenarios.
+impl<I> ItemReader<I> for PostgresRdbcItemReader<I>
+where
+    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
+{
+    /// Reads the next item from the PostgreSQL database.
+    ///
+    /// Manages automatic pagination: loads a new page when the buffer is exhausted,
+    /// handles both LIMIT/OFFSET and keyset pagination transparently.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok(Some(item))` if an item was successfully read
+    /// - `Ok(None)` if there are no more items to read (end of result set)
+    /// - `Err(BatchError::ItemReader)` if a database error occurred
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::core::item::ItemReader;
+    /// use spring_batch_rs::item::rdbc::RdbcItemReaderBuilder;
+    /// use sqlx::PgPool;
+    /// # use serde::Deserialize;
+    /// # #[derive(sqlx::FromRow, Clone, Deserialize)]
+    /// # struct User { id: i32, name: String }
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+    /// let reader = RdbcItemReaderBuilder::<User>::new()
+    ///     .postgres(pool)
+    ///     .query("SELECT id, name FROM users ORDER BY id")
+    ///     .with_page_size(100)
+    ///     .build_postgres();
+    ///
+    /// // Read items one by one
+    /// let mut count = 0;
+    /// while let Some(user) = reader.read()? {
+    ///     println!("User: {} - {}", user.id, user.name);
+    ///     count += 1;
+    /// }
+    /// println!("Processed {} users", count);
+    /// # Ok(())
+    /// # }
+    /// ```
+    fn read(&self) -> ItemReaderResult<I> {
+        let index = calculate_page_index(self.offset.get(), self.page_size);
+
+        if should_load_page(index) {
+            self.read_page()?;
+        }
+
+        let result = self.buffer.borrow().get(index as usize).cloned();
+
+        if let (Some(item), Some(key_fn)) = (&result, &self.keyset_key) {
+            *self.last_cursor.borrow_mut() = Some(key_fn(item));
+        }
+
+        self.offset.set(self.offset.get() + 1);
+
+        Ok(result)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -189,84 +245,5 @@ mod tests {
             reader.last_cursor.borrow().is_none(),
             "cursor must start as None before first read"
         );
-    }
-}
-
-impl<I> ItemReader<I> for PostgresRdbcItemReader<I>
-where
-    for<'r> I: FromRow<'r, PgRow> + Send + Unpin + Clone,
-{
-    /// Reads the next item from the PostgreSQL database
-    ///
-    /// This method implements the ItemReader trait and provides the core reading logic
-    /// with automatic pagination management:
-    ///
-    /// 1. **Index Calculation**: Determines the current position within the current page
-    /// 2. **Page Loading**: Loads a new page if we're at the beginning of a page
-    /// 3. **Item Retrieval**: Returns the item at the current position from the buffer
-    /// 4. **Offset Management**: Advances the offset for the next read operation
-    ///
-    /// # Pagination Logic
-    ///
-    /// For paginated reading (when page_size is Some):
-    /// - `index = offset % page_size` gives position within current page
-    /// - When `index == 0`, we're at the start of a new page and need to load data
-    /// - Buffer contains only the current page's items
-    ///
-    /// For non-paginated reading (when page_size is None):
-    /// - `index = offset` gives absolute position in the full result set
-    /// - Data is loaded only once when `index == 0` (first read)
-    /// - Buffer contains all items from the query
-    ///
-    /// # Returns
-    ///
-    /// - `Ok(Some(item))` if an item was successfully read
-    /// - `Ok(None)` if there are no more items to read (end of result set)
-    /// - `Err(BatchError::ItemReader)` if a database error occurred
-    ///
-    /// # Examples
-    ///
-    /// ```ignore
-    /// use spring_batch_rs::core::item::ItemReader;
-    /// # use spring_batch_rs::item::rdbc::PostgresRdbcItemReader;
-    /// # use sqlx::PgPool;
-    /// # use serde::Deserialize;
-    /// # #[derive(sqlx::FromRow, Clone, Deserialize)]
-    /// # struct User { id: i32, name: String }
-    ///
-    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// # let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
-    /// let reader = PostgresRdbcItemReader::<User>::new(
-    ///     pool,
-    ///     "SELECT id, name FROM users ORDER BY id",
-    ///     Some(100)
-    /// );
-    ///
-    /// // Read items one by one
-    /// let mut count = 0;
-    /// while let Some(user) = reader.read()? {
-    ///     println!("User: {} - {}", user.id, user.name);
-    ///     count += 1;
-    /// }
-    /// println!("Processed {} users", count);
-    /// # Ok(())
-    /// # }
-    /// ```
-    fn read(&self) -> ItemReaderResult<I> {
-        let index = calculate_page_index(self.offset.get(), self.page_size);
-
-        if should_load_page(index) {
-            self.read_page()?;
-        }
-
-        let result = self.buffer.borrow().get(index as usize).cloned();
-
-        if let (Some(item), Some(key_fn)) = (&result, &self.keyset_key) {
-            *self.last_cursor.borrow_mut() = Some(key_fn(item));
-        }
-
-        self.offset.set(self.offset.get() + 1);
-
-        Ok(result)
     }
 }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sqlx::{Pool, Postgres, QueryBuilder};
 
 use crate::core::item::{ItemWriter, ItemWriterResult};
-use crate::item::rdbc::DatabaseItemBinder;
+use crate::item::rdbc::ColumnValue;
 
 use super::writer_common::{
     create_write_error, log_write_success, max_items_per_batch, validate_config,
@@ -10,170 +10,146 @@ use super::writer_common::{
 
 /// A writer for inserting items into a PostgreSQL database using SQLx.
 ///
-/// This writer provides an implementation of the `ItemWriter` trait for PostgreSQL operations.
-/// It supports batch inserting items into a specified table with the provided columns.
-///
-/// # PostgreSQL-Specific Features
-///
-/// - Supports PostgreSQL's advanced data types (JSON, arrays, custom types)
-/// - Handles PostgreSQL's SERIAL and BIGSERIAL for auto-incrementing columns
-/// - Supports PostgreSQL's UPSERT operations with ON CONFLICT clauses
-/// - Leverages PostgreSQL's efficient bulk insert capabilities
-/// - Compatible with PostgreSQL's connection pooling and prepared statements
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
 ///
 /// # Construction
 ///
-/// This writer can only be created through `RdbcItemWriterBuilder`.
-/// Direct construction is not available to ensure proper configuration.
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use spring_batch_rs::core::item::ItemWriter;
-/// use sqlx::{PgPool, query_builder::Separated, Postgres};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::PgPool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
-/// struct User {
-///     id: i32,
-///     name: String,
-/// }
-///
-/// struct UserBinder;
-/// impl DatabaseItemBinder<User, Postgres> for UserBinder {
-///     fn bind(&self, item: &User, mut query_builder: Separated<Postgres, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///     }
-/// }
+/// struct User { id: i32, name: String }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
-/// let binder = UserBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<User>::new()
 ///     .postgres(&pool)
 ///     .table("users")
-///     .add_column("id")
-///     .add_column("name")
-///     .postgres_binder(&binder)
+///     .column("id", |u: &User| u.id.into())
+///     .column("name", |u: &User| u.name.as_str().into())
 ///     .build_postgres();
-///
-/// let users = vec![
-///     User { id: 1, name: "Alice".to_string() },
-///     User { id: 2, name: "Bob".to_string() },
-/// ];
-///
-/// writer.write(&users)?;
 /// # Ok(())
 /// # }
 /// ```
-pub struct PostgresItemWriter<'a, O> {
-    pub(crate) pool: Option<&'a Pool<Postgres>>,
-    pub(crate) table: Option<&'a str>,
-    pub(crate) columns: Vec<&'a str>,
-    pub(crate) item_binder: Option<&'a dyn DatabaseItemBinder<O, Postgres>>,
+pub struct PostgresItemWriter<O> {
+    pub(crate) pool: Option<sqlx::Pool<Postgres>>,
+    pub(crate) table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
 }
 
-impl<'a, O> PostgresItemWriter<'a, O> {
+impl<O> PostgresItemWriter<O> {
     /// Creates a new `PostgresItemWriter` with default configuration.
-    ///
-    /// This constructor is only accessible within the crate to enforce the use
-    /// of `RdbcItemWriterBuilder` for creating writer instances.
     pub(crate) fn new() -> Self {
         Self {
             pool: None,
             table: None,
-            columns: Vec::new(),
-            item_binder: None,
+            column_bindings: Vec::new(),
         }
     }
 
     /// Sets the database connection pool for the writer.
-    pub(crate) fn pool(mut self, pool: &'a Pool<Postgres>) -> Self {
-        self.pool = Some(pool);
+    pub(crate) fn pool(mut self, pool: &Pool<Postgres>) -> Self {
+        self.pool = Some(pool.clone());
         self
     }
 
     /// Sets the table name for the writer.
-    pub(crate) fn table(mut self, table: &'a str) -> Self {
-        self.table = Some(table);
+    pub(crate) fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
         self
     }
 
-    /// Adds a column to the writer.
-    pub(crate) fn add_column(mut self, column: &'a str) -> Self {
-        self.columns.push(column);
-        self
-    }
-
-    /// Sets the item binder for the writer.
-    pub(crate) fn item_binder(
+    /// Adds a column binding to the writer.
+    pub(crate) fn add_column_binding(
         mut self,
-        item_binder: &'a dyn DatabaseItemBinder<O, Postgres>,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
     ) -> Self {
-        self.item_binder = Some(item_binder);
+        self.column_bindings.push((name, extractor));
         self
     }
 }
 
-impl<'a, O> Default for PostgresItemWriter<'a, O> {
+impl<O> Default for PostgresItemWriter<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<'_, O> {
+impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
     fn write(&self, items: &[O]) -> ItemWriterResult {
         if items.is_empty() {
             return Ok(());
         }
 
-        // TODO: TASK 3 — update validate_config to new signature
-        // Validate configuration
-        // let (pool, table, item_binder) =
-        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
 
-        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
-        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
+        let col_names: Vec<&str> = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
 
-        // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
         query_builder.push(table);
         query_builder.push(" (");
-        query_builder.push(self.columns.join(","));
+        query_builder.push(col_names.join(","));
         query_builder.push(") ");
 
-        // Calculate max items per batch and add values
-        let max_items = max_items_per_batch(self.columns.len());
-        let items_to_write = items.iter().take(max_items);
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
         let items_count = items_to_write.len();
 
-        // TODO: TASK 3 — bind items using new API
-        // query_builder.push_values(items_to_write, |b, item| {
-        //     item_binder.bind(item, b);
-        // });
-
-        // Return early for now to let tests compile
-        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
-
-        // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        #[allow(unreachable_code)]
-        {
-            let query = query_builder.build();
-            let result = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-            });
-
-            match result {
-                Ok(_) => {
-                    log_write_success(items_count, table, "PostgreSQL");
-                    Ok(())
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Float(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Text(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bool(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bytes(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Null => {
+                        b.push_bind(Option::<String>::None);
+                    }
                 }
-                Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
             }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "PostgreSQL");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
         }
     }
 }
@@ -181,90 +157,54 @@ impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<'_, O> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::item::ItemWriter;
+    use crate::item::rdbc::ColumnValue;
 
     #[test]
-    fn test_new_creates_default_writer() {
+    fn should_start_with_empty_state() {
         let writer = PostgresItemWriter::<String>::new();
-
         assert!(writer.pool.is_none());
         assert!(writer.table.is_none());
-        assert!(writer.columns.is_empty());
-        assert!(writer.item_binder.is_none());
+        assert!(writer.column_bindings.is_empty());
     }
 
     #[test]
-    fn test_builder_pattern_configuration() {
+    fn should_store_column_bindings_in_order() {
         let writer = PostgresItemWriter::<String>::new()
-            .table("users")
-            .add_column("id")
-            .add_column("name")
-            .add_column("email");
-
-        assert_eq!(writer.table, Some("users"));
-        assert_eq!(writer.columns, vec!["id", "name", "email"]);
+            .add_column_binding("x".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("y".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["x", "y"]);
     }
 
     #[test]
-    fn test_write_empty_items() {
-        use crate::item::rdbc::DatabaseItemBinder;
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Postgres> for DummyBinder {
-            fn bind(&self, _item: &String, _query_builder: Separated<Postgres, &str>) {}
-        }
-
-        let binder = DummyBinder;
-        let writer = PostgresItemWriter::<String>::new()
-            .table("test")
-            .add_column("value")
-            .item_binder(&binder);
-
-        let result = writer.write(&[]);
-        assert!(result.is_ok());
+    fn should_return_ok_for_empty_items() {
+        let writer = PostgresItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
     }
 
     #[test]
-    fn should_return_error_when_columns_missing_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Postgres> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<Postgres, &str>) {}
-        }
-        let binder = DummyBinder;
-        let writer = PostgresItemWriter::<String>::new()
-            .table("t")
-            .item_binder(&binder); // no columns
-
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = PostgresItemWriter::<String>::new().table("t");
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing columns");
-        match result.unwrap_err() {
+        match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
     }
 
     #[test]
-    fn should_return_error_when_pool_not_configured_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Postgres> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<Postgres, &str>) {}
-        }
-        let binder = DummyBinder;
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
         let writer = PostgresItemWriter::<String>::new()
             .table("t")
-            .add_column("v")
-            .item_binder(&binder); // no pool
-
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing pool");
-        match result.unwrap_err() {
+        match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -131,9 +131,13 @@ impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<'_, O> {
             return Ok(());
         }
 
+        // TODO: TASK 3 — update validate_config to new signature
         // Validate configuration
-        let (pool, table, item_binder) =
-            validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        // let (pool, table, item_binder) =
+        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+
+        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
+        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
 
         // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
@@ -147,22 +151,29 @@ impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<'_, O> {
         let items_to_write = items.iter().take(max_items);
         let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |b, item| {
-            item_binder.bind(item, b);
-        });
+        // TODO: TASK 3 — bind items using new API
+        // query_builder.push_values(items_to_write, |b, item| {
+        //     item_binder.bind(item, b);
+        // });
+
+        // Return early for now to let tests compile
+        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
 
         // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+        #[allow(unreachable_code)]
+        {
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "PostgreSQL");
-                Ok(())
+            match result {
+                Ok(_) => {
+                    log_write_success(items_count, table, "PostgreSQL");
+                    Ok(())
+                }
+                Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
             }
-            Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
         }
     }
 }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -104,53 +104,53 @@ impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
             .map(|(n, _)| n.as_str())
             .collect();
 
-        let mut query_builder = QueryBuilder::new("INSERT INTO ");
-        query_builder.push(table);
-        query_builder.push(" (");
-        query_builder.push(col_names.join(","));
-        query_builder.push(") ");
-
+        let col_list = col_names.join(",");
         let max_items = max_items_per_batch(self.column_bindings.len());
-        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
-        let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |mut b, item| {
-            for (_, extractor) in &self.column_bindings {
-                match extractor(item) {
-                    ColumnValue::Int(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Float(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Text(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bool(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bytes(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Null => {
-                        b.push_bind(Option::<String>::None);
+        for chunk in items.chunks(max_items) {
+            let mut query_builder = QueryBuilder::new("INSERT INTO ");
+            query_builder.push(table);
+            query_builder.push(" (");
+            query_builder.push(&col_list);
+            query_builder.push(") ");
+
+            query_builder.push_values(chunk.iter(), |mut b, item| {
+                for (_, extractor) in &self.column_bindings {
+                    match extractor(item) {
+                        ColumnValue::Int(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Float(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Text(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bool(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bytes(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Null => {
+                            b.push_bind(Option::<String>::None);
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "PostgreSQL");
-                Ok(())
+            if let Err(e) = result {
+                return Err(create_write_error(table, "PostgreSQL", e));
             }
-            Err(e) => Err(create_write_error(table, "PostgreSQL", e)),
         }
+
+        log_write_success(items.len(), table, "PostgreSQL");
+        Ok(())
     }
 }
 

--- a/src/item/rdbc/select_builder.rs
+++ b/src/item/rdbc/select_builder.rs
@@ -502,12 +502,10 @@ impl<I> SelectBuilder<I> {
     ///
     /// struct Event { id: i64 }
     ///
-    /// let builder = SelectBuilder::<Event>::from("events")
-    ///     .order_by_keyset("id", |e: &Event| e.id.to_string());
+    /// let sql = SelectBuilder::<Event>::from("events")
+    ///     .order_by_keyset("id", |e: &Event| e.id.to_string())
+    ///     .build_sql();
     ///
-    /// assert_eq!(builder.keyset_column.as_deref(), Some("id"));
-    ///
-    /// let sql = builder.build_sql();
     /// assert_eq!(sql, "SELECT * FROM events ORDER BY id ASC");
     /// ```
     pub fn order_by_keyset(
@@ -850,5 +848,13 @@ mod tests {
             sql, "SELECT * FROM events ORDER BY id ASC",
             "keyset pagination should produce ORDER BY id ASC"
         );
+    }
+
+    #[test]
+    fn should_generate_where_gte_for_float() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gte("score", 4.5_f64)
+            .build_sql();
+        assert_eq!(sql, "SELECT * FROM orders WHERE score >= 4.5", "unexpected: {sql}");
     }
 }

--- a/src/item/rdbc/select_builder.rs
+++ b/src/item/rdbc/select_builder.rs
@@ -442,8 +442,7 @@ impl<I> SelectBuilder<I> {
     /// assert_eq!(sql, "SELECT * FROM users WHERE confirmed_at IS NOT NULL");
     /// ```
     pub fn where_is_not_null(mut self, col: &str) -> Self {
-        self.conditions
-            .push(WhereClause::IsNotNull(col.to_owned()));
+        self.conditions.push(WhereClause::IsNotNull(col.to_owned()));
         self
     }
 
@@ -508,11 +507,7 @@ impl<I> SelectBuilder<I> {
     ///
     /// assert_eq!(sql, "SELECT * FROM events ORDER BY id ASC");
     /// ```
-    pub fn order_by_keyset(
-        mut self,
-        col: &str,
-        key_fn: impl Fn(&I) -> String + 'static,
-    ) -> Self {
+    pub fn order_by_keyset(mut self, col: &str, key_fn: impl Fn(&I) -> String + 'static) -> Self {
         self.order_by.clear();
         self.order_by.push(OrderClause::Asc(col.to_owned()));
         self.keyset_column = Some(col.to_owned());
@@ -578,6 +573,30 @@ impl<I> SelectBuilder<I> {
 
         sql
     }
+
+    /// Generates the base SQL string without the `ORDER BY` clause.
+    ///
+    /// Used internally when keyset pagination is active, since the reader
+    /// constructs the `ORDER BY` clause itself. Calling this method on a builder
+    /// that has no `ORDER BY` configured produces the same result as
+    /// [`SelectBuilder::build_sql`].
+    pub(crate) fn build_sql_no_order(&self) -> String {
+        let cols = if self.columns.is_empty() {
+            "*".to_string()
+        } else {
+            self.columns.join(", ")
+        };
+
+        let mut sql = format!("SELECT {} FROM {}", cols, self.table);
+
+        if !self.conditions.is_empty() {
+            let clauses: Vec<String> = self.conditions.iter().map(WhereClause::to_sql).collect();
+            sql.push_str(" WHERE ");
+            sql.push_str(&clauses.join(" AND "));
+        }
+
+        sql
+    }
 }
 
 // ──────────────────────────────────────────────────────────────────────────────
@@ -595,7 +614,10 @@ mod tests {
     #[test]
     fn should_generate_select_star_when_no_columns_given() {
         let sql = SelectBuilder::<Dummy>::from("users").build_sql();
-        assert_eq!(sql, "SELECT * FROM users", "expected SELECT * when no columns specified");
+        assert_eq!(
+            sql, "SELECT * FROM users",
+            "expected SELECT * when no columns specified"
+        );
     }
 
     #[test]
@@ -855,6 +877,51 @@ mod tests {
         let sql = SelectBuilder::<Dummy>::from("orders")
             .where_gte("score", 4.5_f64)
             .build_sql();
-        assert_eq!(sql, "SELECT * FROM orders WHERE score >= 4.5", "unexpected: {sql}");
+        assert_eq!(
+            sql, "SELECT * FROM orders WHERE score >= 4.5",
+            "unexpected: {sql}"
+        );
+    }
+
+    // ── build_sql_no_order ────────────────────────────────────────────────────
+
+    #[test]
+    fn should_omit_order_by_in_build_sql_no_order() {
+        let sql = SelectBuilder::<Dummy>::from("events")
+            .columns(&["id", "name"])
+            .order_by_keyset("id", |_: &Dummy| "1".to_owned())
+            .build_sql_no_order();
+        assert_eq!(
+            sql, "SELECT id, name FROM events",
+            "build_sql_no_order should not include ORDER BY clause"
+        );
+    }
+
+    #[test]
+    fn should_preserve_where_conditions_in_build_sql_no_order() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_eq("active", true)
+            .order_by_keyset("id", |_: &Dummy| "1".to_owned())
+            .build_sql_no_order();
+        assert_eq!(
+            sql, "SELECT * FROM items WHERE active = true",
+            "build_sql_no_order should keep WHERE conditions but drop ORDER BY"
+        );
+    }
+
+    #[test]
+    fn should_match_build_sql_when_no_order_by_configured() {
+        let without_order = SelectBuilder::<Dummy>::from("users")
+            .columns(&["id"])
+            .where_eq("status", "ACTIVE")
+            .build_sql_no_order();
+        let with_build_sql = SelectBuilder::<Dummy>::from("users")
+            .columns(&["id"])
+            .where_eq("status", "ACTIVE")
+            .build_sql();
+        assert_eq!(
+            without_order, with_build_sql,
+            "build_sql_no_order should equal build_sql when no ORDER BY is set"
+        );
     }
 }

--- a/src/item/rdbc/select_builder.rs
+++ b/src/item/rdbc/select_builder.rs
@@ -1,0 +1,854 @@
+//! Fluent SQL SELECT builder for RDBC item readers.
+//!
+//! This module provides [`SelectBuilder`], a type-safe fluent API for constructing
+//! SQL `SELECT` statements with optional `WHERE` conditions and `ORDER BY` clauses.
+//!
+//! # Key Types
+//!
+//! - [`SelectBuilder`] — the public builder; configure via method chaining and call
+//!   [`SelectBuilder::build_sql`] to get the final SQL string.
+//!
+//! # Examples
+//!
+//! ```
+//! use spring_batch_rs::item::rdbc::SelectBuilder;
+//!
+//! struct Row;
+//!
+//! let sql = SelectBuilder::<Row>::from("users")
+//!     .columns(&["id", "name", "email"])
+//!     .where_eq("active", true)
+//!     .order_by_asc("name")
+//!     .build_sql();
+//!
+//! assert_eq!(sql, "SELECT id, name, email FROM users WHERE active = true ORDER BY name ASC");
+//! ```
+
+use std::marker::PhantomData;
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A typed SQL literal value used inside WHERE conditions.
+///
+/// Users never construct this directly; instead they pass any type that
+/// implements `Into<ConditionValue>` (e.g. `i32`, `bool`, `&str`).
+pub(crate) enum ConditionValue {
+    /// A 64-bit signed integer.
+    Integer(i64),
+    /// A 64-bit floating-point number.
+    Float(f64),
+    /// A text string.
+    Text(String),
+    /// A boolean.
+    Bool(bool),
+}
+
+impl ConditionValue {
+    /// Renders the value as a SQL literal string.
+    pub(crate) fn to_sql(&self) -> String {
+        match self {
+            ConditionValue::Integer(n) => n.to_string(),
+            ConditionValue::Float(f) => f.to_string(),
+            ConditionValue::Bool(b) => b.to_string(),
+            ConditionValue::Text(s) => format!("'{}'", s.replace('\'', "''")),
+        }
+    }
+}
+
+// `From` implementations — cover the most common primitive types.
+
+impl From<i32> for ConditionValue {
+    fn from(v: i32) -> Self {
+        ConditionValue::Integer(i64::from(v))
+    }
+}
+
+impl From<i64> for ConditionValue {
+    fn from(v: i64) -> Self {
+        ConditionValue::Integer(v)
+    }
+}
+
+impl From<f32> for ConditionValue {
+    fn from(v: f32) -> Self {
+        ConditionValue::Float(f64::from(v))
+    }
+}
+
+impl From<f64> for ConditionValue {
+    fn from(v: f64) -> Self {
+        ConditionValue::Float(v)
+    }
+}
+
+impl From<bool> for ConditionValue {
+    fn from(v: bool) -> Self {
+        ConditionValue::Bool(v)
+    }
+}
+
+impl From<&str> for ConditionValue {
+    fn from(v: &str) -> Self {
+        ConditionValue::Text(v.to_owned())
+    }
+}
+
+impl From<String> for ConditionValue {
+    fn from(v: String) -> Self {
+        ConditionValue::Text(v)
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A single WHERE predicate.
+pub(crate) enum WhereClause {
+    /// `col = val`
+    Eq(String, ConditionValue),
+    /// `col != val`
+    NotEq(String, ConditionValue),
+    /// `col > val`
+    Gt(String, ConditionValue),
+    /// `col >= val`
+    Gte(String, ConditionValue),
+    /// `col < val`
+    Lt(String, ConditionValue),
+    /// `col <= val`
+    Lte(String, ConditionValue),
+    /// `col LIKE 'pattern'`
+    Like(String, String),
+    /// `col IS NULL`
+    IsNull(String),
+    /// `col IS NOT NULL`
+    IsNotNull(String),
+}
+
+impl WhereClause {
+    /// Renders the clause as a SQL fragment.
+    pub(crate) fn to_sql(&self) -> String {
+        match self {
+            WhereClause::Eq(col, val) => format!("{} = {}", col, val.to_sql()),
+            WhereClause::NotEq(col, val) => format!("{} != {}", col, val.to_sql()),
+            WhereClause::Gt(col, val) => format!("{} > {}", col, val.to_sql()),
+            WhereClause::Gte(col, val) => format!("{} >= {}", col, val.to_sql()),
+            WhereClause::Lt(col, val) => format!("{} < {}", col, val.to_sql()),
+            WhereClause::Lte(col, val) => format!("{} <= {}", col, val.to_sql()),
+            WhereClause::Like(col, pat) => {
+                format!("{} LIKE '{}'", col, pat.replace('\'', "''"))
+            }
+            WhereClause::IsNull(col) => format!("{} IS NULL", col),
+            WhereClause::IsNotNull(col) => format!("{} IS NOT NULL", col),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A single ORDER BY directive.
+pub(crate) enum OrderClause {
+    /// `col ASC`
+    Asc(String),
+    /// `col DESC`
+    Desc(String),
+}
+
+impl OrderClause {
+    fn to_sql(&self) -> String {
+        match self {
+            OrderClause::Asc(col) => format!("{} ASC", col),
+            OrderClause::Desc(col) => format!("{} DESC", col),
+        }
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public struct
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Fluent builder for SQL `SELECT` statements used by RDBC item readers.
+///
+/// Call [`SelectBuilder::from`] to create a builder for a given table, chain
+/// optional filter/order methods, then call [`SelectBuilder::build_sql`] to
+/// obtain the final SQL string.
+///
+/// # Type Parameters
+///
+/// * `I` — The item type that will be read from the database. Used only for
+///   the keyset key function; when keyset pagination is not needed `I` can be
+///   any type (e.g. a unit struct).
+///
+/// # Examples
+///
+/// ```
+/// use spring_batch_rs::item::rdbc::SelectBuilder;
+///
+/// struct Product;
+///
+/// let sql = SelectBuilder::<Product>::from("products")
+///     .columns(&["id", "name", "price"])
+///     .where_gte("price", 10.0_f64)
+///     .where_eq("active", true)
+///     .order_by_desc("price")
+///     .build_sql();
+///
+/// assert!(sql.starts_with("SELECT id, name, price FROM products WHERE"));
+/// assert!(sql.contains("ORDER BY price DESC"));
+/// ```
+pub struct SelectBuilder<I> {
+    table: String,
+    columns: Vec<String>,
+    conditions: Vec<WhereClause>,
+    order_by: Vec<OrderClause>,
+    /// Column name used as the keyset cursor.
+    pub(crate) keyset_column: Option<String>,
+    /// Extracts the keyset cursor value from the last-read item.
+    #[allow(clippy::type_complexity)]
+    pub(crate) keyset_key_fn: Option<Box<dyn Fn(&I) -> String>>,
+    _phantom: PhantomData<I>,
+}
+
+#[allow(private_bounds)]
+impl<I> SelectBuilder<I> {
+    /// Creates a new `SelectBuilder` targeting the given table.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("orders").build_sql();
+    /// assert_eq!(sql, "SELECT * FROM orders");
+    /// ```
+    pub fn from(table: impl Into<String>) -> Self {
+        SelectBuilder {
+            table: table.into(),
+            columns: Vec::new(),
+            conditions: Vec::new(),
+            order_by: Vec::new(),
+            keyset_column: None,
+            keyset_key_fn: None,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Specifies the columns to select.
+    ///
+    /// When not called (or called with an empty slice), the query uses `SELECT *`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .columns(&["id", "email"])
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT id, email FROM users");
+    /// ```
+    pub fn columns(mut self, cols: &[&str]) -> Self {
+        self.columns = cols.iter().map(|c| c.to_string()).collect();
+        self
+    }
+
+    /// Adds a `col = val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .where_eq("status", "ACTIVE")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users WHERE status = 'ACTIVE'");
+    /// ```
+    pub fn where_eq(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Eq(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col != val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .where_not_eq("role", "ADMIN")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users WHERE role != 'ADMIN'");
+    /// ```
+    pub fn where_not_eq(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::NotEq(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col > val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("orders")
+    ///     .where_gt("amount", 100_i32)
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM orders WHERE amount > 100");
+    /// ```
+    pub fn where_gt(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Gt(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col >= val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("orders")
+    ///     .where_gte("score", 4.5_f64)
+    ///     .build_sql();
+    ///
+    /// assert!(sql.starts_with("SELECT * FROM orders WHERE score >= "));
+    /// ```
+    pub fn where_gte(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Gte(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col < val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("items")
+    ///     .where_lt("stock", 10_i32)
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM items WHERE stock < 10");
+    /// ```
+    pub fn where_lt(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Lt(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col <= val` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("items")
+    ///     .where_lte("rank", 100_i32)
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM items WHERE rank <= 100");
+    /// ```
+    pub fn where_lte(mut self, col: &str, val: impl Into<ConditionValue>) -> Self {
+        self.conditions
+            .push(WhereClause::Lte(col.to_owned(), val.into()));
+        self
+    }
+
+    /// Adds a `col LIKE 'pattern'` condition.
+    ///
+    /// Single quotes in `pat` are escaped automatically.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .where_like("email", "%@corp.com")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users WHERE email LIKE '%@corp.com'");
+    /// ```
+    pub fn where_like(mut self, col: &str, pat: &str) -> Self {
+        self.conditions
+            .push(WhereClause::Like(col.to_owned(), pat.to_owned()));
+        self
+    }
+
+    /// Adds a `col IS NULL` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .where_is_null("deleted_at")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users WHERE deleted_at IS NULL");
+    /// ```
+    pub fn where_is_null(mut self, col: &str) -> Self {
+        self.conditions.push(WhereClause::IsNull(col.to_owned()));
+        self
+    }
+
+    /// Adds a `col IS NOT NULL` condition.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .where_is_not_null("confirmed_at")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users WHERE confirmed_at IS NOT NULL");
+    /// ```
+    pub fn where_is_not_null(mut self, col: &str) -> Self {
+        self.conditions
+            .push(WhereClause::IsNotNull(col.to_owned()));
+        self
+    }
+
+    /// Appends an `ORDER BY col ASC` clause.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .order_by_asc("created_at")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users ORDER BY created_at ASC");
+    /// ```
+    pub fn order_by_asc(mut self, col: &str) -> Self {
+        self.order_by.push(OrderClause::Asc(col.to_owned()));
+        self
+    }
+
+    /// Appends an `ORDER BY col DESC` clause.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("users")
+    ///     .order_by_desc("score")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(sql, "SELECT * FROM users ORDER BY score DESC");
+    /// ```
+    pub fn order_by_desc(mut self, col: &str) -> Self {
+        self.order_by.push(OrderClause::Desc(col.to_owned()));
+        self
+    }
+
+    /// Configures keyset (cursor-based) pagination on `col`.
+    ///
+    /// Clears any previously configured `ORDER BY` clauses, sets `ORDER BY col ASC`,
+    /// and stores `col` and `key_fn` for use by the reader at runtime.
+    ///
+    /// `key_fn` extracts the cursor value (as a `String`) from the last item
+    /// returned by a page, so the next page can request `WHERE col > last_cursor`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Event { id: i64 }
+    ///
+    /// let builder = SelectBuilder::<Event>::from("events")
+    ///     .order_by_keyset("id", |e: &Event| e.id.to_string());
+    ///
+    /// assert_eq!(builder.keyset_column.as_deref(), Some("id"));
+    ///
+    /// let sql = builder.build_sql();
+    /// assert_eq!(sql, "SELECT * FROM events ORDER BY id ASC");
+    /// ```
+    pub fn order_by_keyset(
+        mut self,
+        col: &str,
+        key_fn: impl Fn(&I) -> String + 'static,
+    ) -> Self {
+        self.order_by.clear();
+        self.order_by.push(OrderClause::Asc(col.to_owned()));
+        self.keyset_column = Some(col.to_owned());
+        self.keyset_key_fn = Some(Box::new(key_fn));
+        self
+    }
+
+    /// Builds and returns the SQL `SELECT` statement.
+    ///
+    /// - If no columns were specified, emits `SELECT *`.
+    /// - Multiple WHERE conditions are joined with `AND`.
+    /// - Multiple ORDER BY clauses are joined with `, `.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::SelectBuilder;
+    ///
+    /// struct Row;
+    ///
+    /// let sql = SelectBuilder::<Row>::from("orders")
+    ///     .columns(&["id", "total"])
+    ///     .where_eq("status", "OPEN")
+    ///     .where_gt("total", 0_i32)
+    ///     .order_by_asc("id")
+    ///     .build_sql();
+    ///
+    /// assert_eq!(
+    ///     sql,
+    ///     "SELECT id, total FROM orders WHERE status = 'OPEN' AND total > 0 ORDER BY id ASC"
+    /// );
+    /// ```
+    pub fn build_sql(&self) -> String {
+        let col_part = if self.columns.is_empty() {
+            "*".to_owned()
+        } else {
+            self.columns.join(", ")
+        };
+
+        let mut sql = format!("SELECT {} FROM {}", col_part, self.table);
+
+        if !self.conditions.is_empty() {
+            let where_part = self
+                .conditions
+                .iter()
+                .map(WhereClause::to_sql)
+                .collect::<Vec<_>>()
+                .join(" AND ");
+            sql.push_str(" WHERE ");
+            sql.push_str(&where_part);
+        }
+
+        if !self.order_by.is_empty() {
+            let order_part = self
+                .order_by
+                .iter()
+                .map(OrderClause::to_sql)
+                .collect::<Vec<_>>()
+                .join(", ");
+            sql.push_str(" ORDER BY ");
+            sql.push_str(&order_part);
+        }
+
+        sql
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct Dummy;
+
+    // ── SELECT column list ────────────────────────────────────────────────────
+
+    #[test]
+    fn should_generate_select_star_when_no_columns_given() {
+        let sql = SelectBuilder::<Dummy>::from("users").build_sql();
+        assert_eq!(sql, "SELECT * FROM users", "expected SELECT * when no columns specified");
+    }
+
+    #[test]
+    fn should_generate_column_list() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .columns(&["id", "amount", "status"])
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT id, amount, status FROM orders",
+            "column list was not rendered correctly"
+        );
+    }
+
+    // ── WHERE conditions ─────────────────────────────────────────────────────
+
+    #[test]
+    fn should_generate_where_eq_for_string() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("status", "ACTIVE")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE status = 'ACTIVE'",
+            "string equality condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_integer() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("age", 30_i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE age = 30",
+            "integer equality condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_eq_for_bool() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("active", true)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE active = true",
+            "boolean equality condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_escape_single_quotes_in_string_values() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_eq("name", "O'Brien")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE name = 'O''Brien'",
+            "single quotes in string values were not escaped"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_not_eq() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_not_eq("role", "ADMIN")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE role != 'ADMIN'",
+            "not-equal condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_gt() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gt("amount", 100_i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM orders WHERE amount > 100",
+            "greater-than condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_gte() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_gte("score", 4.5_f64)
+            .build_sql();
+        assert!(
+            sql.starts_with("SELECT * FROM orders WHERE score >= "),
+            "greater-than-or-equal condition was not rendered correctly; got: {sql}"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_lt() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lt("stock", 10_i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM items WHERE stock < 10",
+            "less-than condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_lte() {
+        let sql = SelectBuilder::<Dummy>::from("items")
+            .where_lte("rank", 100_i32)
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM items WHERE rank <= 100",
+            "less-than-or-equal condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_like() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_like("email", "%@corp.com")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE email LIKE '%@corp.com'",
+            "LIKE condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_is_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_null("deleted_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE deleted_at IS NULL",
+            "IS NULL condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_where_is_not_null() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .where_is_not_null("confirmed_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users WHERE confirmed_at IS NOT NULL",
+            "IS NOT NULL condition was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_join_multiple_conditions_with_and() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .where_eq("status", "OPEN")
+            .where_gt("amount", 50_i32)
+            .where_is_null("deleted_at")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT * FROM orders WHERE status = 'OPEN' AND amount > 50 AND deleted_at IS NULL",
+            "multiple conditions were not joined with AND"
+        );
+    }
+
+    // ── ORDER BY ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn should_generate_order_by_asc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("created_at")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users ORDER BY created_at ASC",
+            "ORDER BY ASC was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_desc() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_desc("score")
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM users ORDER BY score DESC",
+            "ORDER BY DESC was not rendered correctly"
+        );
+    }
+
+    #[test]
+    fn should_generate_multiple_order_by_clauses() {
+        let sql = SelectBuilder::<Dummy>::from("users")
+            .order_by_asc("last_name")
+            .order_by_desc("score")
+            .build_sql();
+        assert!(
+            sql.contains("last_name ASC, score DESC"),
+            "multiple ORDER BY clauses were not rendered correctly; got: {sql}"
+        );
+    }
+
+    // ── Full query ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn should_generate_full_select_with_columns_conditions_and_order() {
+        let sql = SelectBuilder::<Dummy>::from("orders")
+            .columns(&["id", "total", "status"])
+            .where_eq("status", "OPEN")
+            .where_gt("total", 0_i32)
+            .order_by_asc("id")
+            .build_sql();
+        assert_eq!(
+            sql,
+            "SELECT id, total, status FROM orders WHERE status = 'OPEN' AND total > 0 ORDER BY id ASC",
+            "full SELECT query was not rendered correctly"
+        );
+    }
+
+    // ── Keyset pagination ─────────────────────────────────────────────────────
+
+    #[test]
+    fn should_set_keyset_column_and_key_fn_on_order_by_keyset() {
+        let builder = SelectBuilder::<Dummy>::from("users")
+            .order_by_keyset("id", |_: &Dummy| "42".to_owned());
+        assert_eq!(
+            builder.keyset_column.as_deref(),
+            Some("id"),
+            "keyset_column was not set correctly"
+        );
+        assert!(
+            builder.keyset_key_fn.is_some(),
+            "keyset_key_fn should be Some after order_by_keyset"
+        );
+    }
+
+    #[test]
+    fn should_replace_previous_order_by_on_keyset() {
+        let sql = SelectBuilder::<Dummy>::from("events")
+            .order_by_desc("created_at")
+            .order_by_keyset("id", |_: &Dummy| "1".to_owned())
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM events ORDER BY id ASC",
+            "previous ORDER BY clauses should be cleared when keyset is configured"
+        );
+    }
+
+    #[test]
+    fn should_generate_order_by_asc_in_sql_for_keyset() {
+        let sql = SelectBuilder::<Dummy>::from("events")
+            .order_by_keyset("id", |_: &Dummy| "1".to_owned())
+            .build_sql();
+        assert_eq!(
+            sql, "SELECT * FROM events ORDER BY id ASC",
+            "keyset pagination should produce ORDER BY id ASC"
+        );
+    }
+}

--- a/src/item/rdbc/sqlite_reader.rs
+++ b/src/item/rdbc/sqlite_reader.rs
@@ -14,12 +14,12 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 /// # Construction
 ///
 /// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
-pub struct SqliteRdbcItemReader<'a, I>
+pub struct SqliteRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, SqliteRow> + Send + Unpin + Clone,
 {
     pub(crate) pool: Pool<Sqlite>,
-    pub(crate) query: &'a str,
+    pub(crate) query: String,
     pub(crate) page_size: Option<i32>,
     pub(crate) offset: Cell<i32>,
     pub(crate) buffer: RefCell<Vec<I>>,
@@ -29,7 +29,7 @@ where
     pub(crate) last_cursor: RefCell<Option<String>>,
 }
 
-impl<'a, I> SqliteRdbcItemReader<'a, I>
+impl<I> SqliteRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, SqliteRow> + Send + Unpin + Clone,
 {
@@ -40,7 +40,7 @@ where
     #[allow(clippy::type_complexity)]
     pub(crate) fn new(
         pool: Pool<Sqlite>,
-        query: &'a str,
+        query: String,
         page_size: Option<i32>,
         keyset_column: Option<String>,
         keyset_key: Option<Box<dyn Fn(&I) -> String>>,
@@ -63,7 +63,7 @@ where
     ///
     /// Returns [`BatchError::ItemReader`] if the query fails.
     fn read_page(&self) -> Result<(), BatchError> {
-        let mut query_builder = QueryBuilder::<Sqlite>::new(self.query);
+        let mut query_builder = QueryBuilder::<Sqlite>::new(&self.query);
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
@@ -95,7 +95,7 @@ where
     }
 }
 
-impl<I> ItemReader<I> for SqliteRdbcItemReader<'_, I>
+impl<I> ItemReader<I> for SqliteRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, SqliteRow> + Send + Unpin + Clone,
 {
@@ -151,8 +151,8 @@ mod tests {
         pool: SqlitePool,
         query: &str,
         page_size: Option<i32>,
-    ) -> SqliteRdbcItemReader<'_, Row> {
-        SqliteRdbcItemReader::<Row>::new(pool, query, page_size, None, None)
+    ) -> SqliteRdbcItemReader<Row> {
+        SqliteRdbcItemReader::<Row>::new(pool, query.to_string(), page_size, None, None)
     }
 
     #[tokio::test(flavor = "multi_thread")]
@@ -242,7 +242,7 @@ mod tests {
         let pool = pool_with_rows(&[(1, "a"), (2, "b"), (3, "c"), (4, "d"), (5, "e")]).await;
         let reader = SqliteRdbcItemReader::<Row>::new(
             pool,
-            "SELECT id, name FROM items",
+            "SELECT id, name FROM items".to_string(),
             Some(2),
             Some("id".to_string()),
             Some(Box::new(|r: &Row| r.id.to_string())),
@@ -264,7 +264,7 @@ mod tests {
         let pool = pool_with_rows(&[(10, "x"), (20, "y")]).await;
         let reader = SqliteRdbcItemReader::<Row>::new(
             pool,
-            "SELECT id, name FROM items",
+            "SELECT id, name FROM items".to_string(),
             Some(2),
             Some("id".to_string()),
             Some(Box::new(|r: &Row| r.id.to_string())),
@@ -293,7 +293,7 @@ mod tests {
         let pool = pool_with_rows(&[]).await;
         let reader = SqliteRdbcItemReader::<Row>::new(
             pool,
-            "SELECT id, name FROM items",
+            "SELECT id, name FROM items".to_string(),
             Some(2),
             Some("id".to_string()),
             Some(Box::new(|r: &Row| r.id.to_string())),

--- a/src/item/rdbc/sqlite_reader.rs
+++ b/src/item/rdbc/sqlite_reader.rs
@@ -1,6 +1,6 @@
 use std::cell::{Cell, RefCell};
 
-use sqlx::{Execute, FromRow, Pool, QueryBuilder, Sqlite, sqlite::SqliteRow};
+use sqlx::{FromRow, Pool, QueryBuilder, Sqlite, sqlite::SqliteRow};
 
 use super::reader_common::{calculate_page_index, should_load_page};
 use crate::BatchError;
@@ -67,10 +67,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                let last = self.last_cursor.borrow();
-                if let Some(ref cursor_val) = *last {
-                    let escaped = cursor_val.replace('\'', "''");
-                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
+                {
+                    let last = self.last_cursor.borrow();
+                    if let Some(ref cursor_val) = *last {
+                        query_builder.push(format!(" WHERE {} > ", col));
+                        query_builder.push_bind(cursor_val.clone());
+                    }
                 }
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
@@ -78,19 +80,17 @@ where
             }
         }
 
-        let query = query_builder.build();
-
+        let query = query_builder.build_query_as::<I>();
         let items = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async {
-                sqlx::query_as::<_, I>(query.sql())
+                query
                     .fetch_all(&self.pool)
                     .await
                     .map_err(|e| BatchError::ItemReader(e.to_string()))
             })
         })?;
 
-        self.buffer.borrow_mut().clear();
-        self.buffer.borrow_mut().extend(items);
+        *self.buffer.borrow_mut() = items;
         Ok(())
     }
 }

--- a/src/item/rdbc/sqlite_reader.rs
+++ b/src/item/rdbc/sqlite_reader.rs
@@ -67,13 +67,12 @@ where
 
         if let Some(page_size) = self.page_size {
             if let Some(ref col) = self.keyset_column {
-                {
-                    let last = self.last_cursor.borrow();
-                    if let Some(ref cursor_val) = *last {
-                        query_builder.push(format!(" WHERE {} > ", col));
-                        query_builder.push_bind(cursor_val.clone());
-                    }
+                let last = self.last_cursor.borrow();
+                if let Some(ref cursor_val) = *last {
+                    let escaped = cursor_val.replace('\'', "''");
+                    query_builder.push(format!(" WHERE {} > '{}'", col, escaped));
                 }
+                drop(last);
                 query_builder.push(format!(" ORDER BY {} LIMIT {}", col, page_size));
             } else {
                 query_builder.push(format!(" LIMIT {} OFFSET {}", page_size, self.offset.get()));

--- a/src/item/rdbc/sqlite_reader.rs
+++ b/src/item/rdbc/sqlite_reader.rs
@@ -9,11 +9,11 @@ use crate::core::item::{ItemReader, ItemReaderResult};
 /// SQLite RDBC Item Reader for batch processing.
 ///
 /// Supports LIMIT/OFFSET pagination (default) and keyset pagination
-/// (enabled via [`RdbcItemReaderBuilder::with_keyset`]).
+/// (enabled via [`RdbcItemReaderBuilder::with_keyset`](crate::item::rdbc::RdbcItemReaderBuilder::with_keyset)).
 ///
 /// # Construction
 ///
-/// Use [`RdbcItemReaderBuilder`] — direct construction is not available.
+/// Prefer [`RdbcItemReaderBuilder`](crate::item::rdbc::RdbcItemReaderBuilder) for ergonomic construction.
 pub struct SqliteRdbcItemReader<I>
 where
     for<'r> I: FromRow<'r, SqliteRow> + Send + Unpin + Clone,

--- a/src/item/rdbc/sqlite_writer.rs
+++ b/src/item/rdbc/sqlite_writer.rs
@@ -98,7 +98,11 @@ impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<O> {
             self.column_bindings.len(),
         )?;
 
-        let col_names: Vec<&str> = self.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
+        let col_names: Vec<&str> = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
 
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
         query_builder.push(table);
@@ -175,7 +179,11 @@ mod tests {
             .iter()
             .map(|(n, _)| n.as_str())
             .collect();
-        assert_eq!(names, vec!["a", "b"], "bindings should preserve insertion order");
+        assert_eq!(
+            names,
+            vec!["a", "b"],
+            "bindings should preserve insertion order"
+        );
     }
 
     #[test]
@@ -271,9 +279,7 @@ mod tests {
                 Box::new(|r: &Row| r.note.clone().into()),
             );
 
-        writer
-            .write(&[Row { id: 1, note: None }])
-            .unwrap();
+        writer.write(&[Row { id: 1, note: None }]).unwrap();
 
         let (note,): (Option<String>,) = sqlx::query_as("SELECT note FROM t WHERE id = 1")
             .fetch_one(&pool)

--- a/src/item/rdbc/sqlite_writer.rs
+++ b/src/item/rdbc/sqlite_writer.rs
@@ -104,53 +104,53 @@ impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<O> {
             .map(|(n, _)| n.as_str())
             .collect();
 
-        let mut query_builder = QueryBuilder::new("INSERT INTO ");
-        query_builder.push(table);
-        query_builder.push(" (");
-        query_builder.push(col_names.join(","));
-        query_builder.push(") ");
-
+        let col_list = col_names.join(",");
         let max_items = max_items_per_batch(self.column_bindings.len());
-        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
-        let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |mut b, item| {
-            for (_, extractor) in &self.column_bindings {
-                match extractor(item) {
-                    ColumnValue::Int(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Float(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Text(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bool(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Bytes(v) => {
-                        b.push_bind(v);
-                    }
-                    ColumnValue::Null => {
-                        b.push_bind(Option::<String>::None);
+        for chunk in items.chunks(max_items) {
+            let mut query_builder = QueryBuilder::new("INSERT INTO ");
+            query_builder.push(table);
+            query_builder.push(" (");
+            query_builder.push(&col_list);
+            query_builder.push(") ");
+
+            query_builder.push_values(chunk.iter(), |mut b, item| {
+                for (_, extractor) in &self.column_bindings {
+                    match extractor(item) {
+                        ColumnValue::Int(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Float(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Text(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bool(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Bytes(v) => {
+                            b.push_bind(v);
+                        }
+                        ColumnValue::Null => {
+                            b.push_bind(Option::<String>::None);
+                        }
                     }
                 }
-            }
-        });
+            });
 
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "SQLite");
-                Ok(())
+            if let Err(e) = result {
+                return Err(create_write_error(table, "SQLite", e));
             }
-            Err(e) => Err(create_write_error(table, "SQLite", e)),
         }
+
+        log_write_success(items.len(), table, "SQLite");
+        Ok(())
     }
 }
 
@@ -254,6 +254,31 @@ mod tests {
             BatchError::ItemWriter(msg) => assert!(msg.contains("SQLite"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_write_all_items_across_multiple_batches() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE t (v TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let writer = SqliteItemWriter::<String>::new()
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        // Write more items than BIND_LIMIT / columns would allow in one INSERT
+        // (e.g. 700 items × 1 col = 700 binds, well under 65535, but the loop is exercised)
+        let items: Vec<String> = (0..700).map(|i| i.to_string()).collect();
+        writer.write(&items).unwrap();
+
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM t")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 700, "all 700 items should have been written");
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/src/item/rdbc/sqlite_writer.rs
+++ b/src/item/rdbc/sqlite_writer.rs
@@ -2,7 +2,7 @@ use serde::Serialize;
 use sqlx::{Pool, QueryBuilder, Sqlite};
 
 use crate::core::item::{ItemWriter, ItemWriterResult};
-use crate::item::rdbc::DatabaseItemBinder;
+use crate::item::rdbc::ColumnValue;
 
 use super::writer_common::{
     create_write_error, log_write_success, max_items_per_batch, validate_config,
@@ -10,165 +10,142 @@ use super::writer_common::{
 
 /// A writer for inserting items into a SQLite database using SQLx.
 ///
-/// This writer provides an implementation of the `ItemWriter` trait for SQLite operations.
-/// It supports batch inserting items into a specified table with the provided columns.
+/// Supports batch INSERT via a list of column bindings supplied through
+/// [`RdbcItemWriterBuilder::column`](crate::item::rdbc::RdbcItemWriterBuilder::column).
 ///
-/// # SQLite-Specific Features
+/// # Construction
 ///
-/// - Supports SQLite's flexible type system
-/// - Handles SQLite's AUTOINCREMENT for auto-incrementing columns
-/// - Supports SQLite's INSERT OR REPLACE operations
-/// - Leverages SQLite's efficient bulk insert capabilities
-/// - Compatible with SQLite's connection pooling and prepared statements
+/// Use [`RdbcItemWriterBuilder`](crate::item::rdbc::RdbcItemWriterBuilder) — direct
+/// construction is not public.
 ///
 /// # Examples
 ///
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use spring_batch_rs::core::item::ItemWriter;
-/// use sqlx::{SqlitePool, query_builder::Separated, Sqlite};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::SqlitePool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
-/// struct Task {
-///     id: i32,
-///     title: String,
-///     completed: bool,
-/// }
-///
-/// struct TaskBinder;
-/// impl DatabaseItemBinder<Task, Sqlite> for TaskBinder {
-///     fn bind(&self, item: &Task, mut query_builder: Separated<Sqlite, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.title);
-///         // In real usage: query_builder.push_bind(item.completed);
-///     }
-/// }
+/// struct Task { id: i32, title: String }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = SqlitePool::connect("sqlite::memory:").await?;
-/// let binder = TaskBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<Task>::new()
 ///     .sqlite(&pool)
 ///     .table("tasks")
-///     .add_column("id")
-///     .add_column("title")
-///     .add_column("completed")
-///     .sqlite_binder(&binder)
+///     .column("id", |t: &Task| t.id.into())
+///     .column("title", |t: &Task| t.title.as_str().into())
 ///     .build_sqlite();
-///
-/// let tasks = vec![
-///     Task { id: 1, title: "Task 1".to_string(), completed: false },
-///     Task { id: 2, title: "Task 2".to_string(), completed: true },
-/// ];
-///
-/// writer.write(&tasks)?;
 /// # Ok(())
 /// # }
 /// ```
-pub struct SqliteItemWriter<'a, O> {
-    pool: Option<&'a Pool<Sqlite>>,
-    table: Option<&'a str>,
-    columns: Vec<&'a str>,
-    item_binder: Option<&'a dyn DatabaseItemBinder<O, Sqlite>>,
+pub struct SqliteItemWriter<O> {
+    pub(crate) pool: Option<sqlx::Pool<Sqlite>>,
+    pub(crate) table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
 }
 
-impl<'a, O> SqliteItemWriter<'a, O> {
+impl<O> SqliteItemWriter<O> {
     /// Creates a new `SqliteItemWriter` with default configuration.
     pub(crate) fn new() -> Self {
         Self {
             pool: None,
             table: None,
-            columns: Vec::new(),
-            item_binder: None,
+            column_bindings: Vec::new(),
         }
     }
 
     /// Sets the database connection pool for the writer.
-    pub(crate) fn pool(mut self, pool: &'a Pool<Sqlite>) -> Self {
-        self.pool = Some(pool);
+    pub(crate) fn pool(mut self, pool: &Pool<Sqlite>) -> Self {
+        self.pool = Some(pool.clone());
         self
     }
 
     /// Sets the table name for the writer.
-    pub(crate) fn table(mut self, table: &'a str) -> Self {
-        self.table = Some(table);
+    pub(crate) fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
         self
     }
 
-    /// Adds a column to the writer.
-    pub(crate) fn add_column(mut self, column: &'a str) -> Self {
-        self.columns.push(column);
-        self
-    }
-
-    /// Sets the item binder for the writer.
-    pub(crate) fn item_binder(
+    /// Adds a column binding to the writer.
+    pub(crate) fn add_column_binding(
         mut self,
-        item_binder: &'a dyn DatabaseItemBinder<O, Sqlite>,
+        name: String,
+        extractor: Box<dyn Fn(&O) -> ColumnValue>,
     ) -> Self {
-        self.item_binder = Some(item_binder);
+        self.column_bindings.push((name, extractor));
         self
     }
 }
 
-impl<'a, O> Default for SqliteItemWriter<'a, O> {
+impl<O> Default for SqliteItemWriter<O> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<'_, O> {
+impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<O> {
     fn write(&self, items: &[O]) -> ItemWriterResult {
         if items.is_empty() {
             return Ok(());
         }
 
-        // TODO: TASK 5 — update validate_config to new signature
-        // Validate configuration
-        // let (pool, table, item_binder) =
-        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
 
-        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
-        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
+        let col_names: Vec<&str> = self.column_bindings.iter().map(|(n, _)| n.as_str()).collect();
 
-        // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
         query_builder.push(table);
         query_builder.push(" (");
-        query_builder.push(self.columns.join(","));
+        query_builder.push(col_names.join(","));
         query_builder.push(") ");
 
-        // Calculate max items per batch and add values
-        let max_items = max_items_per_batch(self.columns.len());
-        let items_to_write = items.iter().take(max_items);
+        let max_items = max_items_per_batch(self.column_bindings.len());
+        let items_to_write: Vec<_> = items.iter().take(max_items).collect();
         let items_count = items_to_write.len();
 
-        // TODO: TASK 5 — bind items using new API
-        // query_builder.push_values(items_to_write, |b, item| {
-        //     item_binder.bind(item, b);
-        // });
-
-        // Return early for now to let tests compile
-        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
-
-        // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        #[allow(unreachable_code)]
-        {
-            let query = query_builder.build();
-            let result = tokio::task::block_in_place(|| {
-                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-            });
-
-            match result {
-                Ok(_) => {
-                    log_write_success(items_count, table, "SQLite");
-                    Ok(())
+        query_builder.push_values(items_to_write, |mut b, item| {
+            for (_, extractor) in &self.column_bindings {
+                match extractor(item) {
+                    ColumnValue::Int(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Float(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Text(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bool(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Bytes(v) => {
+                        b.push_bind(v);
+                    }
+                    ColumnValue::Null => {
+                        b.push_bind(Option::<String>::None);
+                    }
                 }
-                Err(e) => Err(create_write_error(table, "SQLite", e)),
             }
+        });
+
+        let query = query_builder.build();
+        let result = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+        });
+
+        match result {
+            Ok(_) => {
+                log_write_success(items_count, table, "SQLite");
+                Ok(())
+            }
+            Err(e) => Err(create_write_error(table, "SQLite", e)),
         }
     }
 }
@@ -177,74 +154,41 @@ impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<'_, O> {
 mod tests {
     use super::*;
     use crate::core::item::ItemWriter;
+    use crate::item::rdbc::ColumnValue;
 
     #[test]
-    fn test_new_creates_default_writer() {
+    fn should_start_with_empty_state() {
         let writer = SqliteItemWriter::<String>::new();
-
         assert!(writer.pool.is_none());
         assert!(writer.table.is_none());
-        assert!(writer.columns.is_empty());
-        assert!(writer.item_binder.is_none());
+        assert!(writer.column_bindings.is_empty());
     }
 
     #[test]
-    fn test_builder_pattern_configuration() {
-        let writer = SqliteItemWriter::<String>::new()
-            .table("tasks")
-            .add_column("id")
-            .add_column("title")
-            .add_column("completed");
-
-        assert_eq!(writer.table, Some("tasks"));
-        assert_eq!(writer.columns, vec!["id", "title", "completed"]);
-    }
-
-    #[test]
-    fn test_write_empty_items() {
-        use crate::item::rdbc::DatabaseItemBinder;
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Sqlite> for DummyBinder {
-            fn bind(&self, _item: &String, _query_builder: Separated<Sqlite, &str>) {}
-        }
-
-        let binder = DummyBinder;
-        let writer = SqliteItemWriter::<String>::new()
-            .table("test")
-            .add_column("value")
-            .item_binder(&binder);
-
-        let result = writer.write(&[]);
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn should_create_via_default() {
-        let writer = SqliteItemWriter::<String>::default();
-        assert!(writer.pool.is_none());
-        assert!(writer.table.is_none());
-        assert!(writer.columns.is_empty());
-        assert!(writer.item_binder.is_none());
-    }
-
-    #[test]
-    fn should_return_error_when_columns_missing_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Sqlite> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<Sqlite, &str>) {}
-        }
-        let binder = DummyBinder;
+    fn should_store_column_bindings_in_order() {
         let writer = SqliteItemWriter::<String>::new()
             .table("t")
-            .item_binder(&binder); // no columns
+            .add_column_binding("a".to_string(), Box::new(|_| ColumnValue::Null))
+            .add_column_binding("b".to_string(), Box::new(|_| ColumnValue::Null));
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["a", "b"], "bindings should preserve insertion order");
+    }
 
+    #[test]
+    fn should_return_ok_for_empty_items() {
+        let writer = SqliteItemWriter::<String>::new();
+        assert!(writer.write(&[]).is_ok());
+    }
+
+    #[test]
+    fn should_return_error_when_no_columns_and_items_given() {
+        use crate::BatchError;
+        let writer = SqliteItemWriter::<String>::new().table("t");
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing columns");
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
@@ -252,22 +196,12 @@ mod tests {
     }
 
     #[test]
-    fn should_return_error_when_pool_not_configured_and_items_given() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Sqlite> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<Sqlite, &str>) {}
-        }
-        let binder = DummyBinder;
+    fn should_return_error_when_pool_not_configured() {
+        use crate::BatchError;
         let writer = SqliteItemWriter::<String>::new()
             .table("t")
-            .add_column("v")
-            .item_binder(&binder); // no pool
-
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
         let result = writer.write(&["x".to_string()]);
-        assert!(result.is_err(), "expected error for missing pool");
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
@@ -276,31 +210,20 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn should_write_items_to_in_memory_sqlite() {
-        use crate::item::rdbc::DatabaseItemBinder;
-        use sqlx::{SqlitePool, query_builder::Separated};
-
-        struct StringBinder;
-        impl DatabaseItemBinder<String, Sqlite> for StringBinder {
-            fn bind(&self, item: &String, mut q: Separated<Sqlite, &str>) {
-                q.push_bind(item.clone());
-            }
-        }
-
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
         sqlx::query("CREATE TABLE t (v TEXT NOT NULL)")
             .execute(&pool)
             .await
             .unwrap();
 
-        let binder = StringBinder;
         let writer = SqliteItemWriter::<String>::new()
             .pool(&pool)
             .table("t")
-            .add_column("v")
-            .item_binder(&binder);
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
 
-        let items = vec!["hello".to_string(), "world".to_string()];
-        writer.write(&items).unwrap();
+        writer
+            .write(&["hello".to_string(), "world".to_string()])
+            .unwrap();
 
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM t")
             .fetch_one(&pool)
@@ -310,35 +233,52 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn should_return_error_when_sqlite_query_fails() {
-        use crate::{BatchError, item::rdbc::DatabaseItemBinder};
-        use sqlx::{SqlitePool, query_builder::Separated};
-
-        struct StringBinder;
-        impl DatabaseItemBinder<String, Sqlite> for StringBinder {
-            fn bind(&self, item: &String, mut q: Separated<Sqlite, &str>) {
-                q.push_bind(item.clone());
-            }
-        }
-
-        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
-        // Table is NOT created → INSERT will fail
-        let binder = StringBinder;
+    async fn should_return_error_when_query_fails() {
+        use crate::BatchError;
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
         let writer = SqliteItemWriter::<String>::new()
             .pool(&pool)
             .table("nonexistent_table")
-            .add_column("v")
-            .item_binder(&binder);
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
 
         let result = writer.write(&["x".to_string()]);
         match result.err().unwrap() {
-            BatchError::ItemWriter(msg) => {
-                assert!(
-                    msg.contains("SQLite"),
-                    "error should mention SQLite, got: {msg}"
-                )
-            }
-            e => panic!("expected ItemWriter error, got {e:?}"),
+            BatchError::ItemWriter(msg) => assert!(msg.contains("SQLite"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_write_null_for_none_optional_column() {
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query("CREATE TABLE t (id INTEGER NOT NULL, note TEXT)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        #[derive(Clone, serde::Serialize)]
+        struct Row {
+            id: i32,
+            note: Option<String>,
+        }
+
+        let writer = SqliteItemWriter::<Row>::new()
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("id".to_string(), Box::new(|r: &Row| r.id.into()))
+            .add_column_binding(
+                "note".to_string(),
+                Box::new(|r: &Row| r.note.clone().into()),
+            );
+
+        writer
+            .write(&[Row { id: 1, note: None }])
+            .unwrap();
+
+        let (note,): (Option<String>,) = sqlx::query_as("SELECT note FROM t WHERE id = 1")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert!(note.is_none(), "note should be NULL in the database");
     }
 }

--- a/src/item/rdbc/sqlite_writer.rs
+++ b/src/item/rdbc/sqlite_writer.rs
@@ -126,9 +126,13 @@ impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<'_, O> {
             return Ok(());
         }
 
+        // TODO: TASK 5 — update validate_config to new signature
         // Validate configuration
-        let (pool, table, item_binder) =
-            validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+        // let (pool, table, item_binder) =
+        //     validate_config(self.pool, self.table, &self.columns, self.item_binder)?;
+
+        let pool = self.pool.ok_or_else(|| crate::BatchError::ItemWriter("Database pool not configured".to_string()))?;
+        let table = self.table.ok_or_else(|| crate::BatchError::ItemWriter("Table name not configured".to_string()))?;
 
         // Build INSERT query
         let mut query_builder = QueryBuilder::new("INSERT INTO ");
@@ -142,22 +146,29 @@ impl<O: Serialize + Clone> ItemWriter<O> for SqliteItemWriter<'_, O> {
         let items_to_write = items.iter().take(max_items);
         let items_count = items_to_write.len();
 
-        query_builder.push_values(items_to_write, |b, item| {
-            item_binder.bind(item, b);
-        });
+        // TODO: TASK 5 — bind items using new API
+        // query_builder.push_values(items_to_write, |b, item| {
+        //     item_binder.bind(item, b);
+        // });
+
+        // Return early for now to let tests compile
+        return Err(crate::BatchError::ItemWriter("TODO: implement new binding API".to_string()));
 
         // Execute query inline (QueryBuilder lifetime requires this to be in same scope)
-        let query = query_builder.build();
-        let result = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
-        });
+        #[allow(unreachable_code)]
+        {
+            let query = query_builder.build();
+            let result = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(async { query.execute(pool).await })
+            });
 
-        match result {
-            Ok(_) => {
-                log_write_success(items_count, table, "SQLite");
-                Ok(())
+            match result {
+                Ok(_) => {
+                    log_write_success(items_count, table, "SQLite");
+                    Ok(())
+                }
+                Err(e) => Err(create_write_error(table, "SQLite", e)),
             }
-            Err(e) => Err(create_write_error(table, "SQLite", e)),
         }
     }
 }

--- a/src/item/rdbc/unified_reader_builder.rs
+++ b/src/item/rdbc/unified_reader_builder.rs
@@ -6,7 +6,20 @@ use std::marker::PhantomData;
 use super::database_type::DatabaseType;
 use super::mysql_reader::MySqlRdbcItemReader;
 use super::postgres_reader::PostgresRdbcItemReader;
+use super::select_builder::SelectBuilder;
 use super::sqlite_reader::SqliteRdbcItemReader;
+
+/// Source of the SQL query for an RDBC item reader.
+///
+/// This is an internal type used by [`RdbcItemReaderBuilder`] to track whether
+/// the query was provided as a raw string via [`.query()`] or constructed via
+/// a [`SelectBuilder`] with [`.select()`].
+enum QuerySource<'a> {
+    /// A raw SQL string provided directly by the caller.
+    Raw(&'a str),
+    /// A SQL string built by [`SelectBuilder`].
+    Built(String),
+}
 
 /// Unified builder for creating RDBC item readers for any supported database type.
 ///
@@ -84,7 +97,7 @@ pub struct RdbcItemReaderBuilder<'a, I> {
     postgres_pool: Option<Pool<Postgres>>,
     mysql_pool: Option<Pool<MySql>>,
     sqlite_pool: Option<Pool<Sqlite>>,
-    query: Option<&'a str>,
+    query_source: Option<QuerySource<'a>>,
     page_size: Option<i32>,
     db_type: Option<DatabaseType>,
     keyset_column: Option<String>,
@@ -100,7 +113,7 @@ impl<'a, I> RdbcItemReaderBuilder<'a, I> {
             postgres_pool: None,
             mysql_pool: None,
             sqlite_pool: None,
-            query: None,
+            query_source: None,
             page_size: None,
             db_type: None,
             keyset_column: None,
@@ -159,7 +172,58 @@ impl<'a, I> RdbcItemReaderBuilder<'a, I> {
     /// # Returns
     /// The updated builder instance
     pub fn query(mut self, query: &'a str) -> Self {
-        self.query = Some(query);
+        self.query_source = Some(QuerySource::Raw(query));
+        self
+    }
+
+    /// Configures the reader query using a [`SelectBuilder`].
+    ///
+    /// This is an ergonomic alternative to [`.query()`] that lets you build the
+    /// SQL statement through a fluent API instead of writing raw SQL. If the
+    /// [`SelectBuilder`] was configured with [`.order_by_keyset()`], the keyset
+    /// column and key function are automatically propagated to the reader.
+    ///
+    /// Calling `.select()` after `.query()` (or vice-versa) is allowed; the
+    /// **last** call wins.
+    ///
+    /// # Arguments
+    ///
+    /// * `builder` - A [`SelectBuilder`] instance ready to be compiled.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::{RdbcItemReaderBuilder, SelectBuilder};
+    /// use sqlx::SqlitePool;
+    /// # use serde::Deserialize;
+    /// # #[derive(sqlx::FromRow, Clone, Deserialize)]
+    /// # struct Task { id: i32, title: String }
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = SqlitePool::connect("sqlite::memory:").await?;
+    ///
+    /// let reader = RdbcItemReaderBuilder::<Task>::new()
+    ///     .sqlite(pool)
+    ///     .select(
+    ///         SelectBuilder::from("tasks")
+    ///             .columns(&["id", "title"])
+    ///             .where_eq("done", false)
+    ///             .order_by_asc("id"),
+    ///     )
+    ///     .with_page_size(50)
+    ///     .build_sqlite();
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn select(mut self, builder: SelectBuilder<I>) -> Self {
+        let sql = builder.build_sql();
+        if let Some(col) = builder.keyset_column {
+            self.keyset_column = Some(col);
+        }
+        if let Some(key_fn) = builder.keyset_key_fn {
+            self.keyset_key_fn = Some(key_fn);
+        }
+        self.query_source = Some(QuerySource::Built(sql));
         self
     }
 
@@ -236,9 +300,16 @@ where
     /// # Panics
     /// Panics if PostgreSQL pool or query are missing
     pub fn build_postgres(self) -> PostgresRdbcItemReader<I> {
+        let query = match self
+            .query_source
+            .expect("Query is required — call .query() or .select()")
+        {
+            QuerySource::Raw(s) => s.to_string(),
+            QuerySource::Built(s) => s,
+        };
         PostgresRdbcItemReader::new(
             self.postgres_pool.expect("PostgreSQL pool is required"),
-            self.query.expect("Query is required").to_string(),
+            query,
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,
@@ -258,9 +329,16 @@ where
     /// # Panics
     /// Panics if MySQL pool or query are missing
     pub fn build_mysql(self) -> MySqlRdbcItemReader<I> {
+        let query = match self
+            .query_source
+            .expect("Query is required — call .query() or .select()")
+        {
+            QuerySource::Raw(s) => s.to_string(),
+            QuerySource::Built(s) => s,
+        };
         MySqlRdbcItemReader::new(
             self.mysql_pool.expect("MySQL pool is required"),
-            self.query.expect("Query is required").to_string(),
+            query,
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,
@@ -280,9 +358,16 @@ where
     /// # Panics
     /// Panics if SQLite pool or query are missing
     pub fn build_sqlite(self) -> SqliteRdbcItemReader<I> {
+        let query = match self
+            .query_source
+            .expect("Query is required — call .query() or .select()")
+        {
+            QuerySource::Raw(s) => s.to_string(),
+            QuerySource::Built(s) => s,
+        };
         SqliteRdbcItemReader::new(
             self.sqlite_pool.expect("SQLite pool is required"),
-            self.query.expect("Query is required").to_string(),
+            query,
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,
@@ -299,6 +384,7 @@ impl<'a, I> Default for RdbcItemReaderBuilder<'a, I> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use super::super::select_builder::SelectBuilder;
     use sqlx::{FromRow, SqlitePool};
 
     #[derive(Clone, FromRow)]
@@ -380,6 +466,74 @@ mod tests {
         assert!(
             reader.last_cursor.borrow().is_none(),
             "cursor starts as None"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_build_sqlite_reader_from_select_builder() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let reader = RdbcItemReaderBuilder::<Dummy>::new()
+            .sqlite(pool)
+            .select(
+                SelectBuilder::from("items")
+                    .columns(&["id"])
+                    .where_eq("active", true)
+                    .order_by_asc("id"),
+            )
+            .build_sqlite();
+        assert_eq!(
+            reader.query,
+            "SELECT id FROM items WHERE active = true ORDER BY id ASC",
+            "select builder SQL should be stored in reader"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_propagate_keyset_from_select_builder_to_sqlite_reader() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let reader = RdbcItemReaderBuilder::<Dummy>::new()
+            .sqlite(pool)
+            .select(SelectBuilder::from("items").order_by_keyset("id", |d: &Dummy| {
+                d.id.to_string()
+            }))
+            .with_page_size(10)
+            .build_sqlite();
+        assert_eq!(
+            reader.keyset_column.as_deref(),
+            Some("id"),
+            "keyset column should propagate from SelectBuilder"
+        );
+        assert!(
+            reader.keyset_key.is_some(),
+            "keyset key fn should propagate from SelectBuilder"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_prefer_select_over_query_when_called_last() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let reader = RdbcItemReaderBuilder::<Dummy>::new()
+            .sqlite(pool)
+            .query("SELECT id FROM old_table")
+            .select(SelectBuilder::from("new_table").columns(&["id"]))
+            .build_sqlite();
+        assert_eq!(
+            reader.query, "SELECT id FROM new_table",
+            "select() called last should win"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn should_prefer_query_over_select_when_called_last() {
+        let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        let reader = RdbcItemReaderBuilder::<Dummy>::new()
+            .sqlite(pool)
+            .select(SelectBuilder::from("old_table").columns(&["id"]))
+            .query("SELECT id FROM new_table")
+            .build_sqlite();
+        assert_eq!(
+            reader.query, "SELECT id FROM new_table",
+            "query() called last should win"
         );
     }
 }

--- a/src/item/rdbc/unified_reader_builder.rs
+++ b/src/item/rdbc/unified_reader_builder.rs
@@ -235,10 +235,10 @@ where
     ///
     /// # Panics
     /// Panics if PostgreSQL pool or query are missing
-    pub fn build_postgres(self) -> PostgresRdbcItemReader<'a, I> {
+    pub fn build_postgres(self) -> PostgresRdbcItemReader<I> {
         PostgresRdbcItemReader::new(
             self.postgres_pool.expect("PostgreSQL pool is required"),
-            self.query.expect("Query is required"),
+            self.query.expect("Query is required").to_string(),
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,
@@ -257,10 +257,10 @@ where
     ///
     /// # Panics
     /// Panics if MySQL pool or query are missing
-    pub fn build_mysql(self) -> MySqlRdbcItemReader<'a, I> {
+    pub fn build_mysql(self) -> MySqlRdbcItemReader<I> {
         MySqlRdbcItemReader::new(
             self.mysql_pool.expect("MySQL pool is required"),
-            self.query.expect("Query is required"),
+            self.query.expect("Query is required").to_string(),
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,
@@ -279,10 +279,10 @@ where
     ///
     /// # Panics
     /// Panics if SQLite pool or query are missing
-    pub fn build_sqlite(self) -> SqliteRdbcItemReader<'a, I> {
+    pub fn build_sqlite(self) -> SqliteRdbcItemReader<I> {
         SqliteRdbcItemReader::new(
             self.sqlite_pool.expect("SQLite pool is required"),
-            self.query.expect("Query is required"),
+            self.query.expect("Query is required").to_string(),
             self.page_size,
             self.keyset_column,
             self.keyset_key_fn,

--- a/src/item/rdbc/unified_reader_builder.rs
+++ b/src/item/rdbc/unified_reader_builder.rs
@@ -387,8 +387,8 @@ impl<'a, I> Default for RdbcItemReaderBuilder<'a, I> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::select_builder::SelectBuilder;
+    use super::*;
     use sqlx::{FromRow, SqlitePool};
 
     #[derive(Clone, FromRow)]
@@ -486,8 +486,7 @@ mod tests {
             )
             .build_sqlite();
         assert_eq!(
-            reader.query,
-            "SELECT id FROM items WHERE active = true ORDER BY id ASC",
+            reader.query, "SELECT id FROM items WHERE active = true ORDER BY id ASC",
             "select builder SQL should be stored in reader"
         );
     }
@@ -497,9 +496,9 @@ mod tests {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         let reader = RdbcItemReaderBuilder::<Dummy>::new()
             .sqlite(pool)
-            .select(SelectBuilder::from("items").order_by_keyset("id", |d: &Dummy| {
-                d.id.to_string()
-            }))
+            .select(
+                SelectBuilder::from("items").order_by_keyset("id", |d: &Dummy| d.id.to_string()),
+            )
             .with_page_size(10)
             .build_sqlite();
         assert_eq!(
@@ -512,8 +511,7 @@ mod tests {
             "keyset key fn should propagate from SelectBuilder"
         );
         assert_eq!(
-            reader.query,
-            "SELECT * FROM items",
+            reader.query, "SELECT * FROM items",
             "keyset select builder must store SQL without ORDER BY to avoid double ORDER BY in read_page"
         );
     }

--- a/src/item/rdbc/unified_reader_builder.rs
+++ b/src/item/rdbc/unified_reader_builder.rs
@@ -178,9 +178,9 @@ impl<'a, I> RdbcItemReaderBuilder<'a, I> {
 
     /// Configures the reader query using a [`SelectBuilder`].
     ///
-    /// This is an ergonomic alternative to [`.query()`] that lets you build the
+    /// This is an ergonomic alternative to [`Self::query`] that lets you build the
     /// SQL statement through a fluent API instead of writing raw SQL. If the
-    /// [`SelectBuilder`] was configured with [`.order_by_keyset()`], the keyset
+    /// [`SelectBuilder`] was configured with [`SelectBuilder::order_by_keyset`], the keyset
     /// column and key function are automatically propagated to the reader.
     ///
     /// Calling `.select()` after `.query()` (or vice-versa) is allowed; the
@@ -216,7 +216,11 @@ impl<'a, I> RdbcItemReaderBuilder<'a, I> {
     /// # }
     /// ```
     pub fn select(mut self, builder: SelectBuilder<I>) -> Self {
-        let sql = builder.build_sql();
+        let sql = if builder.keyset_column.is_some() {
+            builder.build_sql_no_order()
+        } else {
+            builder.build_sql()
+        };
         if let Some(col) = builder.keyset_column {
             self.keyset_column = Some(col);
         }
@@ -253,7 +257,7 @@ impl<'a, I> RdbcItemReaderBuilder<'a, I> {
     ///   framework appends them automatically.
     /// - The keyset column must be indexed and have unique, sortable values (e.g.
     ///   primary key, UUID, zero-padded string ID).
-    /// - [`with_page_size`] must also be set.
+    /// - [`Self::with_page_size`] must also be set.
     ///
     /// # Arguments
     ///
@@ -506,6 +510,11 @@ mod tests {
         assert!(
             reader.keyset_key.is_some(),
             "keyset key fn should propagate from SelectBuilder"
+        );
+        assert_eq!(
+            reader.query,
+            "SELECT * FROM items",
+            "keyset select builder must store SQL without ORDER BY to avoid double ORDER BY in read_page"
         );
     }
 

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -318,7 +318,7 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
     ///
     /// # Panics
     /// Panics if required SQLite-specific configuration is missing
-    pub fn build_sqlite(self) -> SqliteItemWriter<'a, O> {
+    pub fn build_sqlite(self) -> SqliteItemWriter<O> {
         let mut writer = SqliteItemWriter::new();
 
         if let Some(pool) = self.sqlite_pool {
@@ -329,12 +329,18 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
             writer = writer.table(table);
         }
 
+        // TODO: TASK 4 — Update to use new column() method with extractors
+        // For now, add stub column bindings to maintain validation compatibility
         for column in self.columns {
-            writer = writer.add_column(column);
+            let col_name = column.to_string();
+            writer = writer.add_column_binding(
+                col_name,
+                Box::new(|_| crate::item::rdbc::ColumnValue::Null),
+            );
         }
 
-        if let Some(binder) = self.sqlite_binder {
-            writer = writer.item_binder(binder);
+        if let Some(_binder) = self.sqlite_binder {
+            // TODO: TASK 4 — Migrate to new ColumnValue-based binding
         }
 
         writer

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -465,7 +465,8 @@ mod tests {
     async fn should_transfer_sqlite_pool_to_writer() {
         use crate::BatchError;
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        // Pool set but no binder → error is "binder not configured"
+        // Pool and columns set → attempt to write (will fail because table doesn't exist)
+        // This tests that the pool is correctly transferred to the writer
         let writer = RdbcItemWriterBuilder::<String>::new()
             .sqlite(&pool)
             .table("t")
@@ -474,8 +475,8 @@ mod tests {
         let result = writer.write(&["x".to_string()]);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(
-                msg.contains("binder"),
-                "pool was set so error should be about binder, got: {msg}"
+                msg.contains("SQLite"),
+                "pool was set and columns transferred, so write should execute and fail with SQLite error, got: {msg}"
             ),
             e => panic!("expected ItemWriter, got {e:?}"),
         }

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -1,17 +1,17 @@
 use sqlx::{MySql, Pool, Postgres, Sqlite};
 
-use super::DatabaseItemBinder;
-use super::database_type::DatabaseType;
+use super::column_value::ColumnValue;
 use super::mysql_writer::MySqlItemWriter;
 use super::postgres_writer::PostgresItemWriter;
 use super::sqlite_writer::SqliteItemWriter;
 
 /// Unified builder for creating RDBC item writers for any supported database type.
 ///
-/// This builder provides a consistent API for constructing database writers
+/// This builder provides a consistent, fluent API for constructing database writers
 /// regardless of the underlying database (PostgreSQL, MySQL, or SQLite).
-/// Users specify the database type, connection pool, table, and columns,
-/// and the builder handles the creation of the appropriate writer implementation.
+/// Users specify the connection pool, table name, and column mappings via the
+/// `.column()` method, and call `build_postgres()`, `build_mysql()`, or
+/// `build_sqlite()` to produce the appropriate writer.
 ///
 /// # Type Parameters
 ///
@@ -21,8 +21,8 @@ use super::sqlite_writer::SqliteItemWriter;
 ///
 /// ## PostgreSQL
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use sqlx::{PgPool, query_builder::Separated, Postgres};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::PgPool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
@@ -31,25 +31,14 @@ use super::sqlite_writer::SqliteItemWriter;
 ///     name: String,
 /// }
 ///
-/// struct UserBinder;
-/// impl DatabaseItemBinder<User, Postgres> for UserBinder {
-///     fn bind(&self, item: &User, mut query_builder: Separated<Postgres, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///     }
-/// }
-///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
-/// let binder = UserBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<User>::new()
 ///     .postgres(&pool)
 ///     .table("users")
-///     .add_column("id")
-///     .add_column("name")
-///     .postgres_binder(&binder)
+///     .column("id", |u: &User| u.id.into())
+///     .column("name", |u: &User| u.name.as_str().into())
 ///     .build_postgres();
 /// # Ok(())
 /// # }
@@ -57,35 +46,26 @@ use super::sqlite_writer::SqliteItemWriter;
 ///
 /// ## MySQL
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use sqlx::{MySqlPool, query_builder::Separated, MySql};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::MySqlPool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
 /// struct Product {
 ///     id: i32,
 ///     name: String,
-/// }
-///
-/// struct ProductBinder;
-/// impl DatabaseItemBinder<Product, MySql> for ProductBinder {
-///     fn bind(&self, item: &Product, mut query_builder: Separated<MySql, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.name);
-///     }
+///     price: f64,
 /// }
 ///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
-/// let binder = ProductBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<Product>::new()
 ///     .mysql(&pool)
 ///     .table("products")
-///     .add_column("id")
-///     .add_column("name")
-///     .mysql_binder(&binder)
+///     .column("id", |p: &Product| p.id.into())
+///     .column("name", |p: &Product| p.name.as_str().into())
+///     .column("price", |p: &Product| p.price.into())
 ///     .build_mysql();
 /// # Ok(())
 /// # }
@@ -93,8 +73,8 @@ use super::sqlite_writer::SqliteItemWriter;
 ///
 /// ## SQLite
 /// ```no_run
-/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, DatabaseItemBinder};
-/// use sqlx::{SqlitePool, query_builder::Separated, Sqlite};
+/// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+/// use sqlx::SqlitePool;
 /// use serde::Serialize;
 ///
 /// #[derive(Clone, Serialize)]
@@ -103,42 +83,28 @@ use super::sqlite_writer::SqliteItemWriter;
 ///     title: String,
 /// }
 ///
-/// struct TaskBinder;
-/// impl DatabaseItemBinder<Task, Sqlite> for TaskBinder {
-///     fn bind(&self, item: &Task, mut query_builder: Separated<Sqlite, &str>) {
-///         let _ = (item, query_builder); // Placeholder to avoid unused warnings
-///         // In real usage: query_builder.push_bind(item.id);
-///         // In real usage: query_builder.push_bind(&item.title);
-///     }
-/// }
-///
 /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 /// let pool = SqlitePool::connect("sqlite::memory:").await?;
-/// let binder = TaskBinder;
 ///
 /// let writer = RdbcItemWriterBuilder::<Task>::new()
 ///     .sqlite(&pool)
 ///     .table("tasks")
-///     .add_column("id")
-///     .add_column("title")
-///     .sqlite_binder(&binder)
+///     .column("id", |t: &Task| t.id.into())
+///     .column("title", |t: &Task| t.title.as_str().into())
 ///     .build_sqlite();
 /// # Ok(())
 /// # }
 /// ```
-pub struct RdbcItemWriterBuilder<'a, O> {
-    postgres_pool: Option<&'a Pool<Postgres>>,
-    mysql_pool: Option<&'a Pool<MySql>>,
-    sqlite_pool: Option<&'a Pool<Sqlite>>,
-    table: Option<&'a str>,
-    columns: Vec<&'a str>,
-    postgres_binder: Option<&'a dyn DatabaseItemBinder<O, Postgres>>,
-    mysql_binder: Option<&'a dyn DatabaseItemBinder<O, MySql>>,
-    sqlite_binder: Option<&'a dyn DatabaseItemBinder<O, Sqlite>>,
-    db_type: Option<DatabaseType>,
+pub struct RdbcItemWriterBuilder<O> {
+    postgres_pool: Option<sqlx::Pool<Postgres>>,
+    mysql_pool: Option<sqlx::Pool<MySql>>,
+    sqlite_pool: Option<sqlx::Pool<Sqlite>>,
+    table: Option<String>,
+    #[allow(clippy::type_complexity)]
+    column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
 }
 
-impl<'a, O> RdbcItemWriterBuilder<'a, O> {
+impl<O> RdbcItemWriterBuilder<O> {
     /// Creates a new unified writer builder with default configuration.
     pub fn new() -> Self {
         Self {
@@ -146,50 +112,73 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
             mysql_pool: None,
             sqlite_pool: None,
             table: None,
-            columns: Vec::new(),
-            postgres_binder: None,
-            mysql_binder: None,
-            sqlite_binder: None,
-            db_type: None,
+            column_bindings: Vec::new(),
         }
     }
 
-    /// Sets the PostgreSQL connection pool and database type.
+    /// Sets the PostgreSQL connection pool.
     ///
     /// # Arguments
     /// * `pool` - The PostgreSQL connection pool
     ///
-    /// # Returns
-    /// The updated builder instance configured for PostgreSQL
-    pub fn postgres(mut self, pool: &'a Pool<Postgres>) -> Self {
-        self.postgres_pool = Some(pool);
-        self.db_type = Some(DatabaseType::Postgres);
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::PgPool;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+    /// let builder = RdbcItemWriterBuilder::<String>::new().postgres(&pool);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn postgres(mut self, pool: &Pool<Postgres>) -> Self {
+        self.postgres_pool = Some(pool.clone());
         self
     }
 
-    /// Sets the MySQL connection pool and database type.
+    /// Sets the MySQL connection pool.
     ///
     /// # Arguments
     /// * `pool` - The MySQL connection pool
     ///
-    /// # Returns
-    /// The updated builder instance configured for MySQL
-    pub fn mysql(mut self, pool: &'a Pool<MySql>) -> Self {
-        self.mysql_pool = Some(pool);
-        self.db_type = Some(DatabaseType::MySql);
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::MySqlPool;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
+    /// let builder = RdbcItemWriterBuilder::<String>::new().mysql(&pool);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn mysql(mut self, pool: &Pool<MySql>) -> Self {
+        self.mysql_pool = Some(pool.clone());
         self
     }
 
-    /// Sets the SQLite connection pool and database type.
+    /// Sets the SQLite connection pool.
     ///
     /// # Arguments
     /// * `pool` - The SQLite connection pool
     ///
-    /// # Returns
-    /// The updated builder instance configured for SQLite
-    pub fn sqlite(mut self, pool: &'a Pool<Sqlite>) -> Self {
-        self.sqlite_pool = Some(pool);
-        self.db_type = Some(DatabaseType::Sqlite);
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::SqlitePool;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = SqlitePool::connect("sqlite::memory:").await?;
+    /// let builder = RdbcItemWriterBuilder::<String>::new().sqlite(&pool);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn sqlite(mut self, pool: &Pool<Sqlite>) -> Self {
+        self.sqlite_pool = Some(pool.clone());
         self
     }
 
@@ -198,160 +187,166 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
     /// # Arguments
     /// * `table` - The database table name
     ///
-    /// # Returns
-    /// The updated builder instance
-    pub fn table(mut self, table: &'a str) -> Self {
-        self.table = Some(table);
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    ///
+    /// let builder = RdbcItemWriterBuilder::<String>::new().table("users");
+    /// ```
+    pub fn table(mut self, table: &str) -> Self {
+        self.table = Some(table.to_string());
         self
     }
 
-    /// Adds a column to the writer.
+    /// Adds a column mapping for the writer.
+    ///
+    /// The `extractor` closure is called once per item per write, and must return
+    /// a [`ColumnValue`] representing the value to bind for this column.
+    ///
+    /// Columns are inserted in the order they are added. Each call appends one
+    /// column to the INSERT statement.
     ///
     /// # Arguments
-    /// * `column` - The column name
+    /// * `name` - The column name in the database table
+    /// * `extractor` - Closure that extracts a [`ColumnValue`] from an item
     ///
-    /// # Returns
-    /// The updated builder instance
-    pub fn add_column(mut self, column: &'a str) -> Self {
-        self.columns.push(column);
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::{RdbcItemWriterBuilder, ColumnValue};
+    ///
+    /// struct User { id: i32, name: String }
+    ///
+    /// let builder = RdbcItemWriterBuilder::<User>::new()
+    ///     .column("id", |u: &User| u.id.into())
+    ///     .column("name", |u: &User| u.name.as_str().into());
+    /// ```
+    pub fn column(mut self, name: &str, extractor: impl Fn(&O) -> ColumnValue + 'static) -> Self {
+        self.column_bindings
+            .push((name.to_string(), Box::new(extractor)));
         self
     }
 
-    /// Sets the item binder for PostgreSQL.
-    ///
-    /// # Arguments
-    /// * `binder` - The PostgreSQL-specific item binder
+    /// Builds a PostgreSQL writer from the accumulated configuration.
     ///
     /// # Returns
-    /// The updated builder instance
-    pub fn postgres_binder(mut self, binder: &'a dyn DatabaseItemBinder<O, Postgres>) -> Self {
-        self.postgres_binder = Some(binder);
-        self
-    }
-
-    /// Sets the item binder for MySQL.
+    /// A configured [`PostgresItemWriter`] instance ready to use.
     ///
-    /// # Arguments
-    /// * `binder` - The MySQL-specific item binder
+    /// # Examples
     ///
-    /// # Returns
-    /// The updated builder instance
-    pub fn mysql_binder(mut self, binder: &'a dyn DatabaseItemBinder<O, MySql>) -> Self {
-        self.mysql_binder = Some(binder);
-        self
-    }
-
-    /// Sets the item binder for SQLite.
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::PgPool;
     ///
-    /// # Arguments
-    /// * `binder` - The SQLite-specific item binder
-    ///
-    /// # Returns
-    /// The updated builder instance
-    pub fn sqlite_binder(mut self, binder: &'a dyn DatabaseItemBinder<O, Sqlite>) -> Self {
-        self.sqlite_binder = Some(binder);
-        self
-    }
-
-    /// Builds a PostgreSQL writer.
-    ///
-    /// # Returns
-    /// A configured `PostgresItemWriter` instance
-    ///
-    /// # Panics
-    /// Panics if required PostgreSQL-specific configuration is missing
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = PgPool::connect("postgresql://user:pass@localhost/db").await?;
+    /// let writer = RdbcItemWriterBuilder::<String>::new()
+    ///     .postgres(&pool)
+    ///     .table("t")
+    ///     .column("v", |s: &String| s.as_str().into())
+    ///     .build_postgres();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn build_postgres(self) -> PostgresItemWriter<O> {
         let mut writer = PostgresItemWriter::new();
 
         if let Some(pool) = self.postgres_pool {
-            writer = writer.pool(pool);
+            writer = writer.pool(&pool);
         }
 
         if let Some(table) = self.table {
-            writer = writer.table(table);
+            writer = writer.table(&table);
         }
 
-        // TODO: TASK 6 — Update to use new column() method with extractors
-        for column in self.columns {
-            let col_name = column.to_string();
-            writer = writer
-                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
-        }
-
-        if let Some(_binder) = self.postgres_binder {
-            // TODO: TASK 6 — Migrate to new ColumnValue-based binding
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
         }
 
         writer
     }
 
-    /// Builds a MySQL writer.
+    /// Builds a MySQL writer from the accumulated configuration.
     ///
     /// # Returns
-    /// A configured `MySqlItemWriter` instance
+    /// A configured [`MySqlItemWriter`] instance ready to use.
     ///
-    /// # Panics
-    /// Panics if required MySQL-specific configuration is missing
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::MySqlPool;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = MySqlPool::connect("mysql://user:pass@localhost/db").await?;
+    /// let writer = RdbcItemWriterBuilder::<String>::new()
+    ///     .mysql(&pool)
+    ///     .table("t")
+    ///     .column("v", |s: &String| s.as_str().into())
+    ///     .build_mysql();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn build_mysql(self) -> MySqlItemWriter<O> {
         let mut writer = MySqlItemWriter::new();
 
         if let Some(pool) = self.mysql_pool {
-            writer = writer.pool(pool);
+            writer = writer.pool(&pool);
         }
 
         if let Some(table) = self.table {
-            writer = writer.table(table);
+            writer = writer.table(&table);
         }
 
-        // TODO: TASK 6 — update to use .column() method with proper extractors
-        for column in self.columns {
-            let col_name = column.to_string();
-            writer = writer
-                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
-        }
-
-        if let Some(_binder) = self.mysql_binder {
-            // TODO: TASK 6 — migrate to ColumnValue-based binding
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
         }
 
         writer
     }
 
-    /// Builds a SQLite writer.
+    /// Builds a SQLite writer from the accumulated configuration.
     ///
     /// # Returns
-    /// A configured `SqliteItemWriter` instance
+    /// A configured [`SqliteItemWriter`] instance ready to use.
     ///
-    /// # Panics
-    /// Panics if required SQLite-specific configuration is missing
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use sqlx::SqlitePool;
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let pool = SqlitePool::connect("sqlite::memory:").await?;
+    /// let writer = RdbcItemWriterBuilder::<String>::new()
+    ///     .sqlite(&pool)
+    ///     .table("t")
+    ///     .column("v", |s: &String| s.as_str().into())
+    ///     .build_sqlite();
+    /// # Ok(())
+    /// # }
+    /// ```
     pub fn build_sqlite(self) -> SqliteItemWriter<O> {
         let mut writer = SqliteItemWriter::new();
 
         if let Some(pool) = self.sqlite_pool {
-            writer = writer.pool(pool);
+            writer = writer.pool(&pool);
         }
 
         if let Some(table) = self.table {
-            writer = writer.table(table);
+            writer = writer.table(&table);
         }
 
-        // TODO: TASK 4 — Update to use new column() method with extractors
-        // For now, add stub column bindings to maintain validation compatibility
-        for column in self.columns {
-            let col_name = column.to_string();
-            writer = writer
-                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
-        }
-
-        if let Some(_binder) = self.sqlite_binder {
-            // TODO: TASK 4 — Migrate to new ColumnValue-based binding
+        for (name, extractor) in self.column_bindings {
+            writer = writer.add_column_binding(name, extractor);
         }
 
         writer
     }
 }
 
-impl<'a, O> Default for RdbcItemWriterBuilder<'a, O> {
+impl<O> Default for RdbcItemWriterBuilder<O> {
     fn default() -> Self {
         Self::new()
     }
@@ -361,155 +356,154 @@ impl<'a, O> Default for RdbcItemWriterBuilder<'a, O> {
 mod tests {
     use super::*;
     use crate::core::item::ItemWriter;
-    use sqlx::query_builder::Separated;
+    use crate::item::rdbc::ColumnValue;
 
-    struct NopBinder;
-    impl DatabaseItemBinder<String, Postgres> for NopBinder {
-        fn bind(&self, _: &String, _: Separated<Postgres, &str>) {}
+    // --- helpers ---
+
+    struct User {
+        id: i32,
+        name: String,
     }
-    impl DatabaseItemBinder<String, MySql> for NopBinder {
-        fn bind(&self, _: &String, _: Separated<MySql, &str>) {}
-    }
-    impl DatabaseItemBinder<String, Sqlite> for NopBinder {
-        fn bind(&self, _: &String, _: Separated<Sqlite, &str>) {}
+
+    // --- happy path ---
+
+    #[test]
+    fn should_accumulate_columns_in_order() {
+        let writer = RdbcItemWriterBuilder::<User>::new()
+            .column("id", |u: &User| u.id.into())
+            .column("name", |u: &User| u.name.as_str().into())
+            .build_postgres();
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["id", "name"],
+            "columns must be in insertion order"
+        );
     }
 
     #[test]
-    fn should_set_table_name_in_postgres_writer() {
+    fn should_set_table_in_postgres_writer() {
         let writer = RdbcItemWriterBuilder::<String>::new()
             .table("users")
             .build_postgres();
-        assert_eq!(writer.table.as_deref(), Some("users"));
+        assert_eq!(
+            writer.table.as_deref(),
+            Some("users"),
+            "table name must be transferred to postgres writer"
+        );
     }
 
     #[test]
-    fn should_accumulate_columns_in_postgres_writer() {
+    fn should_set_table_in_mysql_writer() {
         let writer = RdbcItemWriterBuilder::<String>::new()
-            .add_column("id")
-            .add_column("name")
-            .build_postgres();
-        let names: Vec<&str> = writer
-            .column_bindings
-            .iter()
-            .map(|(n, _)| n.as_str())
-            .collect();
-        assert_eq!(names, vec!["id", "name"]);
-    }
-
-    #[test]
-    fn should_transfer_table_and_columns_to_mysql_writer() {
-        let writer = RdbcItemWriterBuilder::<String>::new()
-            .table("orders")
-            .add_column("order_id")
-            .add_column("total")
+            .table("products")
             .build_mysql();
-        assert_eq!(writer.table.as_deref(), Some("orders"));
-        let names: Vec<&str> = writer
-            .column_bindings
-            .iter()
-            .map(|(n, _)| n.as_str())
-            .collect();
-        assert_eq!(names, vec!["order_id", "total"]);
+        assert_eq!(
+            writer.table.as_deref(),
+            Some("products"),
+            "table name must be transferred to mysql writer"
+        );
     }
 
     #[test]
-    fn should_transfer_table_and_columns_to_sqlite_writer() {
+    fn should_set_table_in_sqlite_writer() {
         use crate::BatchError;
         // No pool configured → validate_config will fail on "pool", not on table/columns.
-        // If table or columns were missing the error would mention those instead,
-        // so reaching the "pool" error proves both were transferred correctly.
-        let binder = NopBinder;
+        // Reaching the "pool" error proves that table and column were transferred correctly.
         let writer = RdbcItemWriterBuilder::<String>::new()
             .table("items")
-            .add_column("sku")
-            .sqlite_binder(&binder)
+            .column("sku", |s: &String| s.as_str().into())
             .build_sqlite();
         let result = writer.write(&["x".to_string()]);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(
                 msg.contains("pool"),
-                "table and columns were set so error should be about pool, got: {msg}"
+                "table and columns were set, so error should be about pool, got: {msg}"
             ),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
     }
 
     #[test]
-    fn should_set_postgres_binder() {
-        let binder = NopBinder;
-        // Builder accepts the binder without panicking; full migration to .column() is in Task 6.
-        let writer = RdbcItemWriterBuilder::<String>::new()
-            .postgres_binder(&binder)
-            .build_postgres();
+    fn should_build_via_default() {
+        // Default must not panic and must produce an empty builder.
+        let builder = RdbcItemWriterBuilder::<String>::default();
+        let writer = builder.build_postgres();
+        assert!(
+            writer.table.is_none(),
+            "default builder should have no table"
+        );
         assert!(
             writer.column_bindings.is_empty(),
-            "no .column() calls — bindings should be empty"
+            "default builder should have no column bindings"
         );
     }
 
     #[test]
-    fn should_set_mysql_binder() {
-        let binder = NopBinder;
-        // Builder accepts the binder without panicking; full migration to .column() is in Task 6.
+    fn should_transfer_columns_to_mysql_writer() {
         let writer = RdbcItemWriterBuilder::<String>::new()
-            .mysql_binder(&binder)
+            .column("a", |s: &String| s.as_str().into())
+            .column("b", |_: &String| ColumnValue::Null)
             .build_mysql();
-        assert!(
-            writer.column_bindings.is_empty(),
-            "no .column() calls — bindings should be empty"
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            vec!["a", "b"],
+            "columns must reach mysql writer in order"
         );
     }
 
     #[test]
-    fn should_transfer_sqlite_binder_to_writer() {
-        use crate::BatchError;
-        // With binder set but no pool, write() should fail on "pool" not on "binder"
-        let binder = NopBinder;
+    fn should_transfer_columns_to_sqlite_writer() {
         let writer = RdbcItemWriterBuilder::<String>::new()
-            .table("t")
-            .add_column("v")
-            .sqlite_binder(&binder)
+            .column("x", |_: &String| ColumnValue::Null)
             .build_sqlite();
-        let result = writer.write(&["x".to_string()]);
-        match result.err().unwrap() {
-            BatchError::ItemWriter(msg) => assert!(
-                msg.contains("pool"),
-                "binder was set so error should be about pool, got: {msg}"
-            ),
-            e => panic!("expected ItemWriter, got {e:?}"),
-        }
+        assert_eq!(
+            writer.column_bindings.len(),
+            1,
+            "one column binding should be transferred to sqlite writer"
+        );
+        assert_eq!(writer.column_bindings[0].0, "x");
     }
+
+    #[test]
+    fn should_have_no_pool_by_default_in_postgres_writer() {
+        let writer = RdbcItemWriterBuilder::<String>::new().build_postgres();
+        assert!(writer.pool.is_none(), "pool should be None when not set");
+    }
+
+    #[test]
+    fn should_have_no_pool_by_default_in_mysql_writer() {
+        let writer = RdbcItemWriterBuilder::<String>::new().build_mysql();
+        assert!(writer.pool.is_none(), "pool should be None when not set");
+    }
+
+    // --- async tests ---
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn should_transfer_sqlite_pool_to_writer() {
+    async fn should_transfer_pool_to_sqlite_writer() {
         use crate::BatchError;
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        // Pool and columns set → attempt to write (will fail because table doesn't exist)
-        // This tests that the pool is correctly transferred to the writer
         let writer = RdbcItemWriterBuilder::<String>::new()
             .sqlite(&pool)
             .table("t")
-            .add_column("v")
+            .column("v", |s: &String| s.as_str().into())
             .build_sqlite();
         let result = writer.write(&["x".to_string()]);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(
                 msg.contains("SQLite"),
-                "pool was set and columns transferred, so write should execute and fail with SQLite error, got: {msg}"
+                "pool transferred — should get SQLite DB error, got: {msg}"
             ),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
-    }
-
-    #[test]
-    fn should_have_no_table_by_default_in_mysql_writer() {
-        let writer = RdbcItemWriterBuilder::<String>::new().build_mysql();
-        assert!(writer.table.is_none());
-        assert!(writer.column_bindings.is_empty());
-    }
-
-    #[test]
-    fn should_create_via_default() {
-        let _b = RdbcItemWriterBuilder::<String>::default();
     }
 }

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -292,7 +292,7 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
     ///
     /// # Panics
     /// Panics if required MySQL-specific configuration is missing
-    pub fn build_mysql(self) -> MySqlItemWriter<'a, O> {
+    pub fn build_mysql(self) -> MySqlItemWriter<O> {
         let mut writer = MySqlItemWriter::new();
 
         if let Some(pool) = self.mysql_pool {
@@ -303,12 +303,15 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
             writer = writer.table(table);
         }
 
+        // TODO: TASK 6 — update to use .column() method with proper extractors
         for column in self.columns {
-            writer = writer.add_column(column);
+            let col_name = column.to_string();
+            writer = writer
+                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
         }
 
-        if let Some(binder) = self.mysql_binder {
-            writer = writer.item_binder(binder);
+        if let Some(_binder) = self.mysql_binder {
+            // TODO: TASK 6 — migrate to ColumnValue-based binding
         }
 
         writer
@@ -400,8 +403,13 @@ mod tests {
             .add_column("order_id")
             .add_column("total")
             .build_mysql();
-        assert_eq!(writer.table, Some("orders"));
-        assert_eq!(writer.columns, vec!["order_id", "total"]);
+        assert_eq!(writer.table.as_deref(), Some("orders"));
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["order_id", "total"]);
     }
 
     #[test]
@@ -442,10 +450,14 @@ mod tests {
     #[test]
     fn should_set_mysql_binder() {
         let binder = NopBinder;
+        // Builder accepts the binder without panicking; full migration to .column() is in Task 6.
         let writer = RdbcItemWriterBuilder::<String>::new()
             .mysql_binder(&binder)
             .build_mysql();
-        assert!(writer.item_binder.is_some(), "mysql binder should be set");
+        assert!(
+            writer.column_bindings.is_empty(),
+            "no .column() calls — bindings should be empty"
+        );
     }
 
     #[test]
@@ -493,7 +505,7 @@ mod tests {
     fn should_have_no_table_by_default_in_mysql_writer() {
         let writer = RdbcItemWriterBuilder::<String>::new().build_mysql();
         assert!(writer.table.is_none());
-        assert!(writer.columns.is_empty());
+        assert!(writer.column_bindings.is_empty());
     }
 
     #[test]

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -260,7 +260,7 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
     ///
     /// # Panics
     /// Panics if required PostgreSQL-specific configuration is missing
-    pub fn build_postgres(self) -> PostgresItemWriter<'a, O> {
+    pub fn build_postgres(self) -> PostgresItemWriter<O> {
         let mut writer = PostgresItemWriter::new();
 
         if let Some(pool) = self.postgres_pool {
@@ -271,12 +271,15 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
             writer = writer.table(table);
         }
 
+        // TODO: TASK 6 — Update to use new column() method with extractors
         for column in self.columns {
-            writer = writer.add_column(column);
+            let col_name = column.to_string();
+            writer = writer
+                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
         }
 
-        if let Some(binder) = self.postgres_binder {
-            writer = writer.item_binder(binder);
+        if let Some(_binder) = self.postgres_binder {
+            // TODO: TASK 6 — Migrate to new ColumnValue-based binding
         }
 
         writer
@@ -333,10 +336,8 @@ impl<'a, O> RdbcItemWriterBuilder<'a, O> {
         // For now, add stub column bindings to maintain validation compatibility
         for column in self.columns {
             let col_name = column.to_string();
-            writer = writer.add_column_binding(
-                col_name,
-                Box::new(|_| crate::item::rdbc::ColumnValue::Null),
-            );
+            writer = writer
+                .add_column_binding(col_name, Box::new(|_| crate::item::rdbc::ColumnValue::Null));
         }
 
         if let Some(_binder) = self.sqlite_binder {
@@ -375,7 +376,7 @@ mod tests {
         let writer = RdbcItemWriterBuilder::<String>::new()
             .table("users")
             .build_postgres();
-        assert_eq!(writer.table, Some("users"));
+        assert_eq!(writer.table.as_deref(), Some("users"));
     }
 
     #[test]
@@ -384,7 +385,12 @@ mod tests {
             .add_column("id")
             .add_column("name")
             .build_postgres();
-        assert_eq!(writer.columns, vec!["id", "name"]);
+        let names: Vec<&str> = writer
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect();
+        assert_eq!(names, vec!["id", "name"]);
     }
 
     #[test]
@@ -423,12 +429,13 @@ mod tests {
     #[test]
     fn should_set_postgres_binder() {
         let binder = NopBinder;
+        // Builder accepts the binder without panicking; full migration to .column() is in Task 6.
         let writer = RdbcItemWriterBuilder::<String>::new()
             .postgres_binder(&binder)
             .build_postgres();
         assert!(
-            writer.item_binder.is_some(),
-            "postgres binder should be set"
+            writer.column_bindings.is_empty(),
+            "no .column() calls — bindings should be empty"
         );
     }
 

--- a/src/item/rdbc/writer_common.rs
+++ b/src/item/rdbc/writer_common.rs
@@ -140,7 +140,10 @@ mod tests {
     async fn should_return_ok_when_all_config_provided() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
         let result = validate_config::<Sqlite>(Some(&pool), Some("tbl"), 1);
-        assert!(result.is_ok(), "should return Ok when all config is provided");
+        assert!(
+            result.is_ok(),
+            "should return Ok when all config is provided"
+        );
     }
 
     #[test]

--- a/src/item/rdbc/writer_common.rs
+++ b/src/item/rdbc/writer_common.rs
@@ -1,42 +1,28 @@
 //! Common functionality for database item writers.
 //!
-//! This module provides shared utilities and constants used across all database-specific
-//! item writers (PostgreSQL, MySQL, SQLite) to reduce code duplication and ensure
-//! consistent behavior.
+//! Provides shared utilities used across PostgreSQL, MySQL, and SQLite writers.
 
 use crate::BatchError;
 use sqlx::{Database, Pool};
 
-/// The maximum number of parameters that can be bound in a single SQL statement.
+/// The maximum number of parameters bound in a single SQL statement.
 /// This is the most conservative limit across major databases (MySQL's limit).
 pub const BIND_LIMIT: usize = 65535;
 
-/// Type alias for the validated configuration tuple returned by `validate_config`.
-type ValidatedConfig<'a, O, DB> = (
-    &'a Pool<DB>,
-    &'a str,
-    &'a dyn super::DatabaseItemBinder<O, DB>,
-);
+/// Type alias for the validated configuration returned by [`validate_config`].
+type ValidatedConfig<'a, DB> = (&'a Pool<DB>, &'a str);
 
 /// Validates that all required writer configuration fields are set.
 ///
-/// # Arguments
+/// # Errors
 ///
-/// * `pool` - The database connection pool
-/// * `table` - The table name
-/// * `columns` - The list of column names
-/// * `item_binder` - The item binder
-///
-/// # Returns
-///
-/// A tuple of validated references, or an error if any required field is missing.
-pub fn validate_config<'a, O, DB: Database>(
+/// Returns [`BatchError::ItemWriter`] if columns is zero, pool is `None`, or table is `None`.
+pub fn validate_config<'a, DB: Database>(
     pool: Option<&'a Pool<DB>>,
     table: Option<&'a str>,
-    columns: &[&'a str],
-    item_binder: Option<&'a dyn super::DatabaseItemBinder<O, DB>>,
-) -> Result<ValidatedConfig<'a, O, DB>, BatchError> {
-    if columns.is_empty() {
+    column_count: usize,
+) -> Result<ValidatedConfig<'a, DB>, BatchError> {
+    if column_count == 0 {
         return Err(BatchError::ItemWriter(
             "No columns specified for database write".to_string(),
         ));
@@ -48,10 +34,7 @@ pub fn validate_config<'a, O, DB: Database>(
     let table =
         table.ok_or_else(|| BatchError::ItemWriter("Table name not configured".to_string()))?;
 
-    let item_binder = item_binder
-        .ok_or_else(|| BatchError::ItemWriter("Item binder not configured".to_string()))?;
-
-    Ok((pool, table, item_binder))
+    Ok((pool, table))
 }
 
 /// Logs a successful write operation.
@@ -81,7 +64,7 @@ pub fn log_write_success(items_count: usize, table: &str, db_name: &str) {
 ///
 /// # Returns
 ///
-/// A `BatchError::ItemWriter` with formatted error message.
+/// A [`BatchError::ItemWriter`] with a formatted error message.
 pub fn create_write_error(table: &str, db_name: &str, error: impl std::fmt::Display) -> BatchError {
     log::error!(
         "Failed to write items to {} table {}: {}",
@@ -92,8 +75,7 @@ pub fn create_write_error(table: &str, db_name: &str, error: impl std::fmt::Disp
     BatchError::ItemWriter(format!("{} write failed: {}", db_name, error))
 }
 
-/// Calculates the maximum number of items that can be written in a single batch
-/// based on the bind limit and number of columns.
+/// Calculates the maximum number of items per batch given the bind limit.
 ///
 /// # Arguments
 ///
@@ -101,7 +83,7 @@ pub fn create_write_error(table: &str, db_name: &str, error: impl std::fmt::Disp
 ///
 /// # Returns
 ///
-/// The maximum number of items per batch.
+/// `BIND_LIMIT / column_count`
 #[inline]
 pub fn max_items_per_batch(column_count: usize) -> usize {
     BIND_LIMIT / column_count
@@ -128,7 +110,7 @@ mod tests {
 
     #[test]
     fn should_return_error_when_columns_is_empty() {
-        let result = validate_config::<String, Sqlite>(None, Some("tbl"), &[], None);
+        let result = validate_config::<Sqlite>(None, Some("tbl"), 0);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("columns"), "unexpected: {msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
@@ -137,8 +119,7 @@ mod tests {
 
     #[test]
     fn should_return_error_when_pool_is_missing() {
-        // columns non-empty, pool = None → "pool not configured"
-        let result = validate_config::<String, Sqlite>(None, Some("tbl"), &["col"], None);
+        let result = validate_config::<Sqlite>(None, Some("tbl"), 1);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "unexpected: {msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
@@ -148,7 +129,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn should_return_error_when_table_is_missing() {
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        let result = validate_config::<String, Sqlite>(Some(&pool), None, &["col"], None);
+        let result = validate_config::<Sqlite>(Some(&pool), None, 1);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("Table"), "unexpected: {msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
@@ -156,37 +137,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn should_return_error_when_binder_is_missing() {
-        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        let result = validate_config::<String, Sqlite>(Some(&pool), Some("tbl"), &["col"], None);
-        match result.err().unwrap() {
-            BatchError::ItemWriter(msg) => assert!(msg.contains("binder"), "unexpected: {msg}"),
-            e => panic!("expected ItemWriter, got {e:?}"),
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn should_return_ok_when_all_config_provided() {
-        use crate::item::rdbc::DatabaseItemBinder;
-        use sqlx::query_builder::Separated;
-
-        struct DummyBinder;
-        impl DatabaseItemBinder<String, Sqlite> for DummyBinder {
-            fn bind(&self, _: &String, _: Separated<Sqlite, &str>) {}
-        }
-
         let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
-        let binder = DummyBinder;
-        let result = validate_config::<String, Sqlite>(
-            Some(&pool),
-            Some("tbl"),
-            &["col"],
-            Some(&binder as &dyn DatabaseItemBinder<String, Sqlite>),
-        );
-        assert!(
-            result.is_ok(),
-            "should return Ok when all config is provided"
-        );
+        let result = validate_config::<Sqlite>(Some(&pool), Some("tbl"), 1);
+        assert!(result.is_ok(), "should return Ok when all config is provided");
     }
 
     #[test]

--- a/tests/helpers/mysql_helpers.rs
+++ b/tests/helpers/mysql_helpers.rs
@@ -1,23 +1,5 @@
 use serde::{Deserialize, Serialize};
-use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-use sqlx::{FromRow, MySql, query_builder::Separated};
-
-/// MySQL-specific item binder for Car items.
-///
-/// This binder handles the conversion of Car domain objects to MySQL-compatible
-/// query parameters. It binds values in the order matching the table schema:
-/// year (SMALLINT), make (VARCHAR), model (VARCHAR), description (VARCHAR).
-#[allow(dead_code)]
-pub struct MySqlCarItemBinder;
-
-impl DatabaseItemBinder<Car, MySql> for MySqlCarItemBinder {
-    fn bind(&self, item: &Car, mut query_builder: Separated<MySql, &str>) {
-        query_builder.push_bind(item.year);
-        query_builder.push_bind(item.make.clone());
-        query_builder.push_bind(item.model.clone());
-        query_builder.push_bind(item.description.clone());
-    }
-}
+use sqlx::FromRow;
 
 /// Car domain model for database operations.
 #[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]

--- a/tests/helpers/postgres_helpers.rs
+++ b/tests/helpers/postgres_helpers.rs
@@ -1,23 +1,5 @@
 use serde::{Deserialize, Serialize};
-use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-use sqlx::{FromRow, Postgres, query_builder::Separated};
-
-/// PostgreSQL-specific item binder for Car items.
-///
-/// This binder handles the conversion of Car domain objects to PostgreSQL-compatible
-/// query parameters. It binds values in the order matching the table schema:
-/// year (SMALLINT), make (TEXT), model (TEXT), description (TEXT).
-#[allow(dead_code)]
-pub struct PostgresCarItemBinder;
-
-impl DatabaseItemBinder<Car, Postgres> for PostgresCarItemBinder {
-    fn bind(&self, item: &Car, mut query_builder: Separated<Postgres, &str>) {
-        query_builder.push_bind(item.year);
-        query_builder.push_bind(item.make.clone());
-        query_builder.push_bind(item.model.clone());
-        query_builder.push_bind(item.description.clone());
-    }
-}
+use sqlx::FromRow;
 
 /// Car domain model for database operations.
 #[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]

--- a/tests/helpers/sqlite_helpers.rs
+++ b/tests/helpers/sqlite_helpers.rs
@@ -1,23 +1,5 @@
 use serde::{Deserialize, Serialize};
-use spring_batch_rs::item::rdbc::DatabaseItemBinder;
-use sqlx::{FromRow, Sqlite, query_builder::Separated};
-
-/// SQLite-specific item binder for Car items.
-///
-/// This binder handles the conversion of Car domain objects to SQLite-compatible
-/// query parameters. It binds values in the order matching the table schema:
-/// year (INTEGER), make (VARCHAR), model (VARCHAR), description (VARCHAR).
-#[allow(dead_code)]
-pub struct SqliteCarItemBinder;
-
-impl DatabaseItemBinder<Car, Sqlite> for SqliteCarItemBinder {
-    fn bind(&self, item: &Car, mut query_builder: Separated<Sqlite, &str>) {
-        query_builder.push_bind(item.year);
-        query_builder.push_bind(item.make.clone());
-        query_builder.push_bind(item.model.clone());
-        query_builder.push_bind(item.description.clone());
-    }
-}
+use sqlx::FromRow;
 
 /// Car domain model for database operations.
 #[derive(Deserialize, Serialize, Debug, Clone, FromRow, PartialEq)]

--- a/tests/rdbc_mysql.rs
+++ b/tests/rdbc_mysql.rs
@@ -208,7 +208,7 @@ async fn mysql_reader_should_read_all_items_with_keyset_pagination()
 
     let reader: MySqlRdbcItemReader<TestUser> = MySqlRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users",
+        "SELECT id, name, email FROM test_users".to_string(),
         Some(3),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),
@@ -239,7 +239,7 @@ async fn mysql_reader_should_cross_page_boundary_with_keyset()
     // page_size=4 with 10 rows means 3 pages — exercises cursor update across boundaries
     let reader: MySqlRdbcItemReader<TestUser> = MySqlRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users",
+        "SELECT id, name, email FROM test_users".to_string(),
         Some(4),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),
@@ -263,7 +263,7 @@ async fn mysql_reader_should_return_none_for_empty_table_with_keyset()
 
     let reader: MySqlRdbcItemReader<TestUser> = MySqlRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users WHERE id > 9999",
+        "SELECT id, name, email FROM test_users WHERE id > 9999".to_string(),
         Some(5),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),

--- a/tests/rdbc_mysql.rs
+++ b/tests/rdbc_mysql.rs
@@ -5,7 +5,7 @@ use std::{io::Read, path::Path};
 use anyhow::Error;
 use helpers::{
     common::{DEFAULT_CHUNK_SIZE, EXPECTED_PERSON_COUNT, EXPECTED_PERSON_CSV, SAMPLE_CARS_CSV},
-    mysql_helpers::{CREATE_CARS_TABLE_SQL, Car, MySqlCarItemBinder, SELECT_ALL_CARS_SQL},
+    mysql_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
 };
 use serde::{Deserialize, Serialize};
 use spring_batch_rs::{
@@ -16,7 +16,7 @@ use spring_batch_rs::{
     },
     item::{
         csv::{csv_reader::CsvItemReaderBuilder, csv_writer::CsvItemWriterBuilder},
-        rdbc::{MySqlRdbcItemReader, RdbcItemReaderBuilder, RdbcItemWriterBuilder},
+        rdbc::{MySqlRdbcItemReader, RdbcItemReaderBuilder},
     },
 };
 use sqlx::{FromRow, MySqlPool, migrate::Migrator};
@@ -151,17 +151,24 @@ async fn write_items_to_database() -> Result<(), Error> {
     // Create table
     sqlx::query(CREATE_CARS_TABLE_SQL).execute(&pool).await?;
 
-    let item_binder = MySqlCarItemBinder;
+    use spring_batch_rs::item::rdbc::mysql_writer::MySqlItemWriter;
 
-    let writer = RdbcItemWriterBuilder::<Car>::new()
-        .mysql(&pool)
+    let writer = MySqlItemWriter::<Car>::new()
+        .pool(&pool)
         .table("cars")
-        .add_column("year")
-        .add_column("make")
-        .add_column("model")
-        .add_column("description")
-        .mysql_binder(&item_binder)
-        .build_mysql();
+        .add_column_binding("year".to_string(), Box::new(|c: &Car| c.year.into()))
+        .add_column_binding(
+            "make".to_string(),
+            Box::new(|c: &Car| c.make.as_str().into()),
+        )
+        .add_column_binding(
+            "model".to_string(),
+            Box::new(|c: &Car| c.model.as_str().into()),
+        )
+        .add_column_binding(
+            "description".to_string(),
+            Box::new(|c: &Car| c.description.as_str().into()),
+        );
 
     let processor = PassThroughProcessor::<Car>::new();
 

--- a/tests/rdbc_mysql.rs
+++ b/tests/rdbc_mysql.rs
@@ -16,7 +16,7 @@ use spring_batch_rs::{
     },
     item::{
         csv::{csv_reader::CsvItemReaderBuilder, csv_writer::CsvItemWriterBuilder},
-        rdbc::{MySqlRdbcItemReader, RdbcItemReaderBuilder},
+        rdbc::{MySqlRdbcItemReader, RdbcItemReaderBuilder, RdbcItemWriterBuilder},
     },
 };
 use sqlx::{FromRow, MySqlPool, migrate::Migrator};
@@ -151,24 +151,14 @@ async fn write_items_to_database() -> Result<(), Error> {
     // Create table
     sqlx::query(CREATE_CARS_TABLE_SQL).execute(&pool).await?;
 
-    use spring_batch_rs::item::rdbc::mysql_writer::MySqlItemWriter;
-
-    let writer = MySqlItemWriter::<Car>::new()
-        .pool(&pool)
+    let writer = RdbcItemWriterBuilder::<Car>::new()
+        .mysql(&pool)
         .table("cars")
-        .add_column_binding("year".to_string(), Box::new(|c: &Car| c.year.into()))
-        .add_column_binding(
-            "make".to_string(),
-            Box::new(|c: &Car| c.make.as_str().into()),
-        )
-        .add_column_binding(
-            "model".to_string(),
-            Box::new(|c: &Car| c.model.as_str().into()),
-        )
-        .add_column_binding(
-            "description".to_string(),
-            Box::new(|c: &Car| c.description.as_str().into()),
-        );
+        .column("year", |c: &Car| c.year.into())
+        .column("make", |c: &Car| c.make.as_str().into())
+        .column("model", |c: &Car| c.model.as_str().into())
+        .column("description", |c: &Car| c.description.as_str().into())
+        .build_mysql();
 
     let processor = PassThroughProcessor::<Car>::new();
 

--- a/tests/rdbc_postgres.rs
+++ b/tests/rdbc_postgres.rs
@@ -267,7 +267,7 @@ async fn postgres_reader_should_read_all_items_without_pagination()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users ORDER BY id",
+        "SELECT * FROM test_users ORDER BY id".to_string(),
         None,
         None,
         None,
@@ -294,7 +294,7 @@ async fn postgres_reader_should_read_items_with_pagination()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users ORDER BY id",
+        "SELECT * FROM test_users ORDER BY id".to_string(),
         Some(3),
         None,
         None,
@@ -321,7 +321,7 @@ async fn postgres_reader_should_handle_empty_result_set() -> Result<(), Box<dyn 
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id > 1000",
+        "SELECT * FROM test_users WHERE id > 1000".to_string(),
         Some(5),
         None,
         None,
@@ -340,7 +340,7 @@ async fn postgres_reader_should_handle_single_page_result() -> Result<(), Box<dy
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id <= 2 ORDER BY id",
+        "SELECT * FROM test_users WHERE id <= 2 ORDER BY id".to_string(),
         Some(5),
         None,
         None,
@@ -365,7 +365,7 @@ async fn postgres_reader_should_handle_page_size_larger_than_result_set()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id <= 3 ORDER BY id",
+        "SELECT * FROM test_users WHERE id <= 3 ORDER BY id".to_string(),
         Some(10),
         None,
         None,
@@ -388,7 +388,7 @@ async fn postgres_reader_should_handle_page_size_of_one() -> Result<(), Box<dyn 
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id <= 3 ORDER BY id",
+        "SELECT * FROM test_users WHERE id <= 3 ORDER BY id".to_string(),
         Some(1),
         None,
         None,
@@ -414,7 +414,7 @@ async fn postgres_reader_should_handle_complex_query_with_where_clause()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id % 2 = 0 ORDER BY id",
+        "SELECT * FROM test_users WHERE id % 2 = 0 ORDER BY id".to_string(),
         Some(2),
         None,
         None,
@@ -440,7 +440,7 @@ async fn postgres_reader_should_maintain_correct_read_order()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users WHERE id <= 5 ORDER BY id",
+        "SELECT * FROM test_users WHERE id <= 5 ORDER BY id".to_string(),
         Some(2),
         None,
         None,
@@ -466,7 +466,7 @@ async fn postgres_reader_should_handle_sequential_reads_correctly()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users ORDER BY id",
+        "SELECT * FROM test_users ORDER BY id".to_string(),
         Some(3),
         None,
         None,
@@ -538,7 +538,7 @@ async fn postgres_reader_should_work_with_different_data_types()
 
     let reader: PostgresRdbcItemReader<TestData> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_data ORDER BY id",
+        "SELECT * FROM test_data ORDER BY id".to_string(),
         Some(1),
         None,
         None,
@@ -574,7 +574,7 @@ async fn postgres_reader_should_handle_large_result_sets_efficiently()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT * FROM test_users ORDER BY id",
+        "SELECT * FROM test_users ORDER BY id".to_string(),
         Some(10),
         None,
         None,
@@ -597,7 +597,7 @@ async fn postgres_reader_should_read_all_items_with_keyset_pagination()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users",
+        "SELECT id, name, email FROM test_users".to_string(),
         Some(3),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),
@@ -628,7 +628,7 @@ async fn postgres_reader_should_cross_page_boundary_with_keyset()
     // page_size=4 with 10 rows means 3 pages — exercises cursor update across boundaries
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users",
+        "SELECT id, name, email FROM test_users".to_string(),
         Some(4),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),
@@ -652,7 +652,7 @@ async fn postgres_reader_should_return_none_for_empty_table_with_keyset()
 
     let reader: PostgresRdbcItemReader<TestUser> = PostgresRdbcItemReader::new(
         pool,
-        "SELECT id, name, email FROM test_users WHERE id > 9999",
+        "SELECT id, name, email FROM test_users WHERE id > 9999".to_string(),
         Some(5),
         Some("id".to_string()),
         Some(Box::new(|u: &TestUser| u.id.to_string())),

--- a/tests/rdbc_postgres.rs
+++ b/tests/rdbc_postgres.rs
@@ -5,7 +5,7 @@ use std::{io::Read, path::Path};
 use anyhow::Error;
 use helpers::{
     common::{DEFAULT_CHUNK_SIZE, EXPECTED_PERSON_COUNT, EXPECTED_PERSON_CSV, SAMPLE_CARS_CSV},
-    postgres_helpers::{CREATE_CARS_TABLE_SQL, Car, PostgresCarItemBinder, SELECT_ALL_CARS_SQL},
+    postgres_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
 };
 use serde::{Deserialize, Serialize};
 use spring_batch_rs::{
@@ -109,16 +109,13 @@ async fn write_items_to_database() -> Result<(), Error> {
     // Create table
     sqlx::query(CREATE_CARS_TABLE_SQL).execute(&pool).await?;
 
-    let item_binder = PostgresCarItemBinder;
-
     let writer = RdbcItemWriterBuilder::<Car>::new()
         .postgres(&pool)
         .table("cars")
-        .add_column("year")
-        .add_column("make")
-        .add_column("model")
-        .add_column("description")
-        .postgres_binder(&item_binder)
+        .column("year", |c: &Car| c.year.into())
+        .column("make", |c: &Car| c.make.as_str().into())
+        .column("model", |c: &Car| c.model.as_str().into())
+        .column("description", |c: &Car| c.description.as_str().into())
         .build_postgres();
 
     let processor = PassThroughProcessor::<Car>::new();

--- a/tests/rdbc_sqlite.rs
+++ b/tests/rdbc_sqlite.rs
@@ -9,13 +9,13 @@ use helpers::{
 use serde::{Deserialize, Serialize};
 use spring_batch_rs::{
     core::{
-        item::PassThroughProcessor,
+        item::{ItemReader, PassThroughProcessor},
         job::{Job, JobBuilder},
         step::{StepBuilder, StepStatus},
     },
     item::{
         csv::{csv_reader::CsvItemReaderBuilder, csv_writer::CsvItemWriterBuilder},
-        rdbc::{RdbcItemReaderBuilder, RdbcItemWriterBuilder},
+        rdbc::{RdbcItemReaderBuilder, RdbcItemWriterBuilder, SelectBuilder},
     },
 };
 use sqlx::{
@@ -168,4 +168,52 @@ async fn write_items_to_database() -> Result<(), sqlx::Error> {
     assert_eq!(car_results.len(), helpers::common::EXPECTED_CAR_COUNT);
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_read_all_pages_via_select_builder_with_keyset() {
+    let pool = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("in-memory SQLite pool should open");
+
+    sqlx::query("CREATE TABLE items (id INTEGER PRIMARY KEY, name TEXT)")
+        .execute(&pool)
+        .await
+        .expect("CREATE TABLE should succeed");
+
+    for i in 1..=5_i32 {
+        sqlx::query("INSERT INTO items (id, name) VALUES (?, ?)")
+            .bind(i)
+            .bind(format!("item{}", i))
+            .execute(&pool)
+            .await
+            .expect("INSERT should succeed");
+    }
+
+    #[derive(Clone, sqlx::FromRow)]
+    struct Item {
+        id: i32,
+        name: String,
+    }
+
+    let reader = RdbcItemReaderBuilder::<Item>::new()
+        .sqlite(pool)
+        .select(
+            SelectBuilder::from("items")
+                .columns(&["id", "name"])
+                .order_by_keyset("id", |i: &Item| i.id.to_string()),
+        )
+        .with_page_size(2)
+        .build_sqlite();
+
+    let mut names = vec![];
+    while let Some(item) = reader.read().unwrap() {
+        names.push(item.name.clone());
+    }
+
+    assert_eq!(
+        names,
+        vec!["item1", "item2", "item3", "item4", "item5"],
+        "should read all items across multiple pages with keyset via SelectBuilder"
+    );
 }

--- a/tests/rdbc_sqlite.rs
+++ b/tests/rdbc_sqlite.rs
@@ -4,7 +4,7 @@ use std::{io::Read, path::Path};
 
 use helpers::{
     common::{DEFAULT_CHUNK_SIZE, EXPECTED_PERSON_COUNT, EXPECTED_PERSON_CSV, SAMPLE_CARS_CSV},
-    sqlite_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL, SqliteCarItemBinder},
+    sqlite_helpers::{CREATE_CARS_TABLE_SQL, Car, SELECT_ALL_CARS_SQL},
 };
 use serde::{Deserialize, Serialize};
 use spring_batch_rs::{
@@ -121,16 +121,13 @@ async fn write_items_to_database() -> Result<(), sqlx::Error> {
     // Create table
     sqlx::query(CREATE_CARS_TABLE_SQL).execute(&pool).await?;
 
-    let item_binder = SqliteCarItemBinder;
-
     let writer = RdbcItemWriterBuilder::<Car>::new()
         .sqlite(&pool)
         .table("cars")
-        .add_column("year")
-        .add_column("make")
-        .add_column("model")
-        .add_column("description")
-        .sqlite_binder(&item_binder)
+        .column("year", |c: &Car| c.year.into())
+        .column("make", |c: &Car| c.make.as_str().into())
+        .column("model", |c: &Car| c.model.as_str().into())
+        .column("description", |c: &Car| c.description.as_str().into())
         .build_sqlite();
 
     let processor = PassThroughProcessor::<Car>::new();
@@ -216,4 +213,48 @@ async fn should_read_all_pages_via_select_builder_with_keyset() {
         vec!["item1", "item2", "item3", "item4", "item5"],
         "should read all items across multiple pages with keyset via SelectBuilder"
     );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn should_write_row_with_null_optional_column() -> Result<(), sqlx::Error> {
+    let pool = SqlitePool::connect("sqlite::memory:").await?;
+    sqlx::query("CREATE TABLE items (id INTEGER NOT NULL, label TEXT)")
+        .execute(&pool)
+        .await?;
+
+    #[derive(Debug, Clone, Serialize)]
+    struct Item {
+        id: i32,
+        label: Option<String>,
+    }
+
+    let writer = RdbcItemWriterBuilder::<Item>::new()
+        .sqlite(&pool)
+        .table("items")
+        .column("id", |i: &Item| i.id.into())
+        .column("label", |i: &Item| i.label.clone().into())
+        .build_sqlite();
+
+    use spring_batch_rs::core::item::ItemWriter;
+    writer.write(&[Item { id: 1, label: None }]).unwrap();
+    writer
+        .write(&[Item {
+            id: 2,
+            label: Some("hello".to_string()),
+        }])
+        .unwrap();
+
+    let rows: Vec<(i32, Option<String>)> =
+        sqlx::query_as("SELECT id, label FROM items ORDER BY id")
+            .fetch_all(&pool)
+            .await?;
+
+    assert_eq!(rows.len(), 2, "should have inserted two rows");
+    assert_eq!(rows[0], (1, None), "first row label should be NULL");
+    assert_eq!(
+        rows[1],
+        (2, Some("hello".to_string())),
+        "second row label should be 'hello'"
+    );
+    Ok(())
 }


### PR DESCRIPTION
## Summary

- **`.column()` API** : remplace `DatabaseItemBinder` par un builder fluent `.column("name", |t| t.field.into())` sur `RdbcItemWriterBuilder` (Postgres, MySQL, SQLite)
- **`SelectBuilder`** : génération SQL fluente via `.select()` sur `RdbcItemReaderBuilder` ; les readers possèdent leur `String` de requête (suppression du lifetime)
- **Perf keyset** : cursor bindé via `push_bind`, chunking sur `BIND_LIMIT`, rollback vers string interpolation pour stabilité
- **Benchmark** : fusion des 3 jobs séparés en un seul job `JobBuilder::new().start(&step1).next(&step2).next(&step3).build()`

## Test Plan

- [ ] `cargo test --all-features` — tous les tests unitaires et d'intégration
- [ ] `cargo clippy --all-features -- -D warnings` — zéro warning
- [ ] `cargo build --release --example benchmark_csv_postgres_xml --features csv,xml,rdbc-postgres` — compile en release
- [ ] Tests rdbc Postgres/MySQL/SQLite avec Docker (testcontainers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)