### PR TITLE
Per-phase step timing, and the async investigation it settles

### DIFF
--- a/.claude/rules/02-unit-tests.md
+++ b/.claude/rules/02-unit-tests.md
@@ -23,7 +23,6 @@ Every source file in `src/` that contains public logic MUST have an inline `#[cf
 
 ## Files that MUST have inline tests added
 
-- `src/item/csv/csv_writer.rs` — no tests
 - `src/item/rdbc/postgres_reader.rs` — no tests (use mocks)
 - `src/item/rdbc/mysql_reader.rs` — no tests (use mocks)
 - `src/item/rdbc/sqlite_reader.rs` — no tests (use mocks)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,20 @@ jobs:
         env:
           RUSTFLAGS: "-Cinstrument-coverage"
 
+      # Diagnostic: nightly Cargo has moved build artefacts before (grcov's
+      # --binary-path broke when target/debug/deps/ stopped existing). If the
+      # next step fails again, this shows where the binaries actually landed.
+      - name: Show target layout
+        run: |
+          echo "--- target/debug (depth 2) ---"
+          find ./target/debug -maxdepth 2 -type d | head -30
+          echo "--- .profraw files ---"
+          find . -name '*.profraw' | head -5
+
       - name: Create coverage report
         run: |
           grcov . \
-            --binary-path ./target/debug/deps/ \
+            --binary-path ./target/debug/ \
             --source-dir . \
             --excl-start 'mod test* \{' \
             --ignore '*test*' \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Spring Batch RS is a Rust implementation of the Spring Batch framework for building enterprise-grade batch processing applications. It provides chunk-oriented processing, extensible readers/writers, and support for multiple data formats and databases.
 
-**Version**: 0.3.0
+**Version**: 0.4.0
 **Language**: Rust 2021 Edition
 **Documentation**: https://spring-batch-rs.boussekeyt.dev/
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Spring Batch RS is a Rust implementation of the Spring Batch framework for building enterprise-grade batch processing applications. It provides chunk-oriented processing, extensible readers/writers, and support for multiple data formats and databases.
 
 **Version**: 0.4.0
-**Language**: Rust 2021 Edition
+**Language**: Rust 2024 Edition
 **Documentation**: https://spring-batch-rs.boussekeyt.dev/
 
 ## Essential Commands

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "spring-batch-rs"
-version = "0.3.6"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spring-batch-rs"
-version = "0.3.6"
+version = "0.4.0"
 edition = "2024"
 authors = ["Simon Boussekeyt <sboussekeyt@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
+++ b/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
@@ -152,49 +152,48 @@ fn should_record_nonzero_read_duration_after_step() {
 }
 
 #[test]
-fn should_attribute_duration_to_the_correct_phase() {
+fn should_attribute_slow_reads_to_read_duration_not_process() {
     let mut reader = MockTestItemReader::default();
     let mut counter = 0u16;
     reader.expect_read().returning(move || {
+        std::thread::sleep(Duration::from_millis(30));
         counter += 1;
-        if counter > 3 { Ok(None) } else { Ok(sample_car()) }
+        if counter > 2 { Ok(None) } else { Ok(sample_car()) }
     });
 
     let processor = PassThroughProcessor::<Car>::new();
 
     let mut writer = MockTestItemWriter::default();
     writer.expect_open().returning(|| Ok(()));
-    writer.expect_write().returning(|_| {
-        std::thread::sleep(Duration::from_millis(50));
-        Ok(())
-    });
+    writer.expect_write().returning(|_| Ok(()));
     writer.expect_flush().returning(|| Ok(()));
     writer.expect_close().returning(|| Ok(()));
 
-    let step = StepBuilder::new("phase-attribution")
+    let step = StepBuilder::new("read-attribution")
         .chunk(10)
         .reader(&reader)
         .processor(&processor)
         .writer(&writer)
         .build();
 
-    let mut step_execution = StepExecution::new("phase-attribution");
+    let mut step_execution = StepExecution::new("read-attribution");
     step.execute(&mut step_execution).unwrap();
 
     assert!(
-        step_execution.write_duration > step_execution.read_duration,
-        "slow writer should dominate: write={:?} read={:?}",
-        step_execution.write_duration,
-        step_execution.read_duration
-    );
-    assert!(
-        step_execution.write_duration > step_execution.process_duration,
-        "slow writer should dominate: write={:?} process={:?}",
-        step_execution.write_duration,
+        step_execution.read_duration > step_execution.process_duration,
+        "a sleeping reader must not have its time attributed to process: read={:?} process={:?}",
+        step_execution.read_duration,
         step_execution.process_duration
     );
 }
 ```
+
+> **Plan correction (2026-08-03, during execution):** this slot originally held
+> `should_attribute_duration_to_the_correct_phase`, which asserted on `write_duration`.
+> That field is only populated by Task 3, so the test failed deterministically inside
+> Task 2 — a cross-task dependency the plan's self-review missed. The test has been moved
+> to Task 3 and replaced here by the read-vs-process equivalent above, which tests the same
+> guarantee using only what Task 2 builds.
 
 Add this helper next to the existing `mock_read` helper (`step.rs:1493`) if no equivalent exists:
 
@@ -318,6 +317,50 @@ fn should_record_flush_duration_separately_from_write() {
         "a slow flush must not be attributed to write: flush={:?} write={:?}",
         step_execution.flush_duration,
         step_execution.write_duration
+    );
+}
+
+#[test]
+fn should_attribute_duration_to_the_correct_phase() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        counter += 1;
+        if counter > 3 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| {
+        std::thread::sleep(Duration::from_millis(50));
+        Ok(())
+    });
+    writer.expect_flush().returning(|| Ok(()));
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("phase-attribution")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("phase-attribution");
+    step.execute(&mut step_execution).unwrap();
+
+    assert!(
+        step_execution.write_duration > step_execution.read_duration,
+        "slow writer should dominate: write={:?} read={:?}",
+        step_execution.write_duration,
+        step_execution.read_duration
+    );
+    assert!(
+        step_execution.write_duration > step_execution.process_duration,
+        "slow writer should dominate: write={:?} process={:?}",
+        step_execution.write_duration,
+        step_execution.process_duration
     );
 }
 

--- a/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
+++ b/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
@@ -1,0 +1,844 @@
+# Step Phase Profiling Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Record how much of each step's wall-clock time is spent reading, processing, writing and flushing, so the follow-up throughput work can be chosen from measurements instead of assumptions.
+
+**Architecture:** Four cumulative `Duration` fields are added to `StepExecution`. `read_chunk` and `process_chunk` are renamed to `*_inner` and wrapped by timing shims (they have multiple early-return points, so inline timing would miss paths). `write_chunk` is timed inline instead, because `write` and `flush` must be attributed separately. A public `StepExecution::phase_summary()` formats the breakdown and is logged at step completion. Separately, `CsvItemWriter` gains the `open`/`close` lifecycle methods it is missing.
+
+**Tech Stack:** Rust 2024 edition, `std::time::{Instant, Duration}`, `log`, `mockall` 0.14 (dev), existing `mock!` blocks in `src/core/step.rs`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-03-step-phase-profiling-design.md`.
+- Branch: `feat-step-phase-profiling` (already created, spec already committed as `f8fef1b`).
+- **No behavioural change to the engine.** The per-chunk `flush()` at `step.rs:845` is measured, not modified or made optional.
+- Timing granularity is **per chunk, never per item**. Wrapping each `reader.read()` would add ~0.3 s of `Instant::now()` overhead on the 10M-row benchmark and contaminate the measurement.
+- Version bumps to `0.4.0`: adding `pub` fields to `StepExecution`, which is not `#[non_exhaustive]`, is formally breaking.
+- Zero-warning policy: `cargo clippy --all-features -- -D warnings` must pass.
+- Never use `println!`; use `log` macros (`CLAUDE.md`).
+- Test naming: `should_<behaviour>_<condition>` (`.claude/rules/02-unit-tests.md`).
+- Every doc-test must assert something (`.claude/rules/01-rustdoc.md`).
+- Website sync is mandatory and docsite pages are **`.mdx`, never `.md`**.
+
+---
+
+### Task 1: Phase duration fields on StepExecution
+
+**Files:**
+- Modify: `src/core/step.rs:331-359` (struct), `src/core/step.rs:380-396` (constructor)
+- Test: `src/core/step.rs` inline `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `StepExecution::read_duration`, `.process_duration`, `.write_duration`, `.flush_duration`, all `pub` and of type `std::time::Duration`, all initialised to `Duration::ZERO`. Tasks 2-4 accumulate into them.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the inline `mod tests` in `src/core/step.rs`:
+
+```rust
+#[test]
+fn should_initialize_phase_durations_to_zero() {
+    let step_execution = StepExecution::new("phase-init");
+
+    assert_eq!(step_execution.read_duration, Duration::ZERO);
+    assert_eq!(step_execution.process_duration, Duration::ZERO);
+    assert_eq!(step_execution.write_duration, Duration::ZERO);
+    assert_eq!(step_execution.flush_duration, Duration::ZERO);
+}
+```
+
+`Duration` needs to be in scope in the test module. If `use std::time::Duration;` is not already imported there, add it.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cargo test --all-features should_initialize_phase_durations_to_zero`
+Expected: FAIL — `no field 'read_duration' on type 'StepExecution'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add the four fields at the end of the `StepExecution` struct (after `write_error_count`, `step.rs:358`):
+
+```rust
+    /// Number of errors encountered during writing
+    pub write_error_count: usize,
+    /// Cumulative time spent inside `ItemReader::read` calls, summed across all chunks
+    pub read_duration: Duration,
+    /// Cumulative time spent inside `ItemProcessor::process` calls, summed across all chunks
+    pub process_duration: Duration,
+    /// Cumulative time spent inside `ItemWriter::write` calls, summed across all chunks
+    pub write_duration: Duration,
+    /// Cumulative time spent inside `ItemWriter::flush` calls, summed across all chunks
+    pub flush_duration: Duration,
+}
+```
+
+And in `StepExecution::new`, after `write_error_count: 0,`:
+
+```rust
+            write_error_count: 0,
+            read_duration: Duration::ZERO,
+            process_duration: Duration::ZERO,
+            write_duration: Duration::ZERO,
+            flush_duration: Duration::ZERO,
+        }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib core::step`
+Expected: PASS, including the 61 pre-existing tests in this module.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/step.rs
+git commit -m "feat: add per-phase duration fields to StepExecution"
+```
+
+---
+
+### Task 2: Time the read and process phases
+
+**Files:**
+- Modify: `src/core/step.rs:729-772` (`read_chunk`), `src/core/step.rs:785-817` (`process_chunk`)
+- Test: `src/core/step.rs` inline `mod tests`
+
+**Interfaces:**
+- Consumes: the four fields from Task 1.
+- Produces: `read_chunk` and `process_chunk` keep their exact existing signatures and become timing shims. The moved bodies become `read_chunk_inner` and `process_chunk_inner` with identical signatures. No caller changes.
+
+**Why a wrapper and not inline timing:** `read_chunk` returns from four different places (`step.rs:748`, `:753`, `:755`, `:767`). Accumulating at each site would be duplicative and easy to get wrong when a path is added later.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the inline `mod tests` in `src/core/step.rs`:
+
+```rust
+#[test]
+fn should_record_nonzero_read_duration_after_step() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        std::thread::sleep(Duration::from_millis(20));
+        counter += 1;
+        if counter > 2 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| Ok(()));
+    writer.expect_flush().returning(|| Ok(()));
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("read-timing")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("read-timing");
+    step.execute(&mut step_execution).unwrap();
+
+    assert!(
+        step_execution.read_duration >= Duration::from_millis(40),
+        "expected read_duration to cover 3 sleeping reads, got {:?}",
+        step_execution.read_duration
+    );
+}
+
+#[test]
+fn should_attribute_duration_to_the_correct_phase() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        counter += 1;
+        if counter > 3 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| {
+        std::thread::sleep(Duration::from_millis(50));
+        Ok(())
+    });
+    writer.expect_flush().returning(|| Ok(()));
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("phase-attribution")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("phase-attribution");
+    step.execute(&mut step_execution).unwrap();
+
+    assert!(
+        step_execution.write_duration > step_execution.read_duration,
+        "slow writer should dominate: write={:?} read={:?}",
+        step_execution.write_duration,
+        step_execution.read_duration
+    );
+    assert!(
+        step_execution.write_duration > step_execution.process_duration,
+        "slow writer should dominate: write={:?} process={:?}",
+        step_execution.write_duration,
+        step_execution.process_duration
+    );
+}
+```
+
+Add this helper next to the existing `mock_read` helper (`step.rs:1493`) if no equivalent exists:
+
+```rust
+fn sample_car() -> Option<Car> {
+    Some(Car {
+        year: 2024,
+        make: "Renault".to_string(),
+        model: "Zoe".to_string(),
+        description: "electric".to_string(),
+    })
+}
+```
+
+`PassThroughProcessor` comes from `crate::core::item::PassThroughProcessor` — add it to the test module's imports if absent.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features should_record_nonzero_read_duration_after_step should_attribute_duration_to_the_correct_phase`
+Expected: FAIL — both assertions fail because durations stay at `Duration::ZERO`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Rename the existing `read_chunk` (the whole body at `step.rs:729-772`) to `read_chunk_inner`, keeping its signature and body byte-for-byte, and add this shim immediately above it:
+
+```rust
+    fn read_chunk(
+        &self,
+        step_execution: &mut StepExecution,
+    ) -> Result<(Vec<I>, ChunkStatus), BatchError> {
+        let start = Instant::now();
+        let result = self.read_chunk_inner(step_execution);
+        step_execution.read_duration += start.elapsed();
+        result
+    }
+```
+
+Do the same for `process_chunk` (`step.rs:785-817`) — rename the existing method to `process_chunk_inner` and add:
+
+```rust
+    fn process_chunk(
+        &self,
+        step_execution: &mut StepExecution,
+        read_items: Vec<I>,
+    ) -> Result<Vec<O>, BatchError> {
+        let start = Instant::now();
+        let result = self.process_chunk_inner(step_execution, read_items);
+        step_execution.process_duration += start.elapsed();
+        result
+    }
+```
+
+Keep the existing rustdoc on the public-facing shims and leave the `*_inner` methods undocumented beyond a one-line `// timed by the wrapper above` comment — they are private.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib core::step`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/step.rs
+git commit -m "feat: time the read and process phases of a chunk step"
+```
+
+---
+
+### Task 3: Time the write and flush phases separately
+
+**Files:**
+- Modify: `src/core/step.rs:830-860` (`write_chunk`)
+- Test: `src/core/step.rs` inline `mod tests`
+
+**Interfaces:**
+- Consumes: fields from Task 1.
+- Produces: `write_duration` covering only `self.writer.write(...)`, `flush_duration` covering only `self.writer.flush()`. Signature of `write_chunk` unchanged.
+
+**Why inline and not a wrapper:** the two calls must be attributed to different fields, so a single wrapper around the method cannot separate them. Isolating `flush_duration` is the whole point — it is what quantifies the cost of the per-chunk flush.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn should_record_flush_duration_separately_from_write() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        counter += 1;
+        if counter > 2 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| Ok(()));
+    writer.expect_flush().returning(|| {
+        std::thread::sleep(Duration::from_millis(30));
+        Ok(())
+    });
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("flush-timing")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("flush-timing");
+    step.execute(&mut step_execution).unwrap();
+
+    assert!(
+        step_execution.flush_duration >= Duration::from_millis(30),
+        "flush_duration should capture the sleeping flush, got {:?}",
+        step_execution.flush_duration
+    );
+    assert!(
+        step_execution.flush_duration > step_execution.write_duration,
+        "a slow flush must not be attributed to write: flush={:?} write={:?}",
+        step_execution.flush_duration,
+        step_execution.write_duration
+    );
+}
+
+#[test]
+fn should_leave_write_duration_at_zero_for_empty_chunk() {
+    let mut reader = MockTestItemReader::default();
+    reader.expect_read().returning(|| Ok(None));
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("empty-chunk")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("empty-chunk");
+    step.execute(&mut step_execution).unwrap();
+
+    assert_eq!(
+        step_execution.write_duration,
+        Duration::ZERO,
+        "the empty-chunk early return skips the writer entirely"
+    );
+    assert_eq!(step_execution.flush_duration, Duration::ZERO);
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features should_record_flush_duration_separately_from_write should_leave_write_duration_at_zero_for_empty_chunk`
+Expected: `should_record_flush_duration_separately_from_write` FAILS (both durations are zero). `should_leave_write_duration_at_zero_for_empty_chunk` may already pass — that is fine, it is a regression guard for the early return at `step.rs:837-840`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Replace the `match` block in `write_chunk` (`step.rs:842-859`) with:
+
+```rust
+        let write_start = Instant::now();
+        let write_result = self.writer.write(processed_items);
+        step_execution.write_duration += write_start.elapsed();
+
+        match write_result {
+            Ok(()) => {
+                step_execution.write_count += processed_items.len();
+
+                let flush_start = Instant::now();
+                let flush_result = self.writer.flush();
+                step_execution.flush_duration += flush_start.elapsed();
+                Self::manage_error(flush_result);
+
+                Ok(())
+            }
+            Err(error) => {
+                warn!("Error writing items: {}", error);
+                step_execution.write_error_count += processed_items.len();
+
+                if self.is_skip_limit_reached(step_execution) {
+                    // Set the status to WriteError to indicate a write failure
+                    step_execution.status = StepStatus::WriteError;
+                    return Err(error);
+                }
+                Ok(())
+            }
+        }
+```
+
+Leave the empty-chunk early return at `step.rs:837-840` untouched — it must keep returning before any writer call.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib core::step`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/step.rs
+git commit -m "feat: time write and flush phases separately"
+```
+
+---
+
+### Task 4: Phase summary formatting and logging
+
+**Files:**
+- Modify: `src/core/step.rs:361-397` (`impl StepExecution`), `src/core/step.rs:658-661` (end of `ChunkOrientedStep::execute`)
+- Test: `src/core/step.rs` inline `mod tests`
+
+**Interfaces:**
+- Consumes: all four duration fields, plus the existing `duration: Option<Duration>` and `name: String`.
+- Produces: `pub fn phase_summary(&self) -> String` on `StepExecution`. Public because the point of this work is letting a user read their own measurements.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[test]
+fn should_format_phase_summary_with_percentages() {
+    let mut step_execution = StepExecution::new("load-postgres");
+    step_execution.duration = Some(Duration::from_secs(10));
+    step_execution.read_duration = Duration::from_secs(5);
+    step_execution.process_duration = Duration::from_secs(1);
+    step_execution.write_duration = Duration::from_secs(3);
+    step_execution.flush_duration = Duration::from_secs(1);
+
+    let summary = step_execution.phase_summary();
+
+    assert!(summary.contains("load-postgres"), "summary: {summary}");
+    assert!(summary.contains("read 5.0s (50%)"), "summary: {summary}");
+    assert!(summary.contains("process 1.0s (10%)"), "summary: {summary}");
+    assert!(summary.contains("write 3.0s (30%)"), "summary: {summary}");
+    assert!(summary.contains("flush 1.0s (10%)"), "summary: {summary}");
+}
+
+#[test]
+fn should_report_zero_percentages_when_duration_is_unset() {
+    let step_execution = StepExecution::new("never-ran");
+
+    let summary = step_execution.phase_summary();
+
+    assert!(summary.contains("(0%)"), "summary: {summary}");
+    assert!(!summary.contains("NaN"), "division by zero leaked: {summary}");
+    assert!(!summary.contains("inf"), "division by zero leaked: {summary}");
+}
+```
+
+The second test is the one that matters: `duration` is `Option<Duration>` and is `None` until `execute` finishes, so a naive percentage computation yields `NaN`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features should_format_phase_summary_with_percentages should_report_zero_percentages_when_duration_is_unset`
+Expected: FAIL — `no method named 'phase_summary'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to `impl StepExecution` (after `new`, `step.rs:396`):
+
+```rust
+    /// Formats the per-phase timing breakdown as a single human-readable line.
+    ///
+    /// Percentages are relative to the step's total [`StepExecution::duration`].
+    /// When `duration` is `None` or zero — for instance before the step has run —
+    /// every percentage is reported as `0%` rather than `NaN`.
+    ///
+    /// The four phases will not sum to exactly 100%: the remainder is framework
+    /// overhead. A large remainder is itself a useful signal.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use spring_batch_rs::core::step::StepExecution;
+    /// use std::time::Duration;
+    ///
+    /// let mut step_execution = StepExecution::new("load-postgres");
+    /// step_execution.duration = Some(Duration::from_secs(10));
+    /// step_execution.read_duration = Duration::from_secs(5);
+    ///
+    /// let summary = step_execution.phase_summary();
+    /// assert!(summary.contains("read 5.0s (50%)"));
+    /// ```
+    pub fn phase_summary(&self) -> String {
+        let total = self.duration.unwrap_or_default().as_secs_f64();
+        let pct = |d: Duration| -> f64 {
+            if total > 0.0 {
+                d.as_secs_f64() / total * 100.0
+            } else {
+                0.0
+            }
+        };
+
+        format!(
+            "Step '{}' {:.1}s — read {:.1}s ({:.0}%) | process {:.1}s ({:.0}%) | write {:.1}s ({:.0}%) | flush {:.1}s ({:.0}%)",
+            self.name,
+            total,
+            self.read_duration.as_secs_f64(),
+            pct(self.read_duration),
+            self.process_duration.as_secs_f64(),
+            pct(self.process_duration),
+            self.write_duration.as_secs_f64(),
+            pct(self.write_duration),
+            self.flush_duration.as_secs_f64(),
+            pct(self.flush_duration),
+        )
+    }
+```
+
+Then in `ChunkOrientedStep::execute`, immediately **after** the duration assignment at `step.rs:661` (it must come after, because `phase_summary` reads `duration`):
+
+```rust
+        step_execution.duration = Some(start_time.elapsed());
+
+        info!("{}", step_execution.phase_summary());
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib core::step && cargo test --doc --all-features core::step`
+Expected: PASS, including the new doc-test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/step.rs
+git commit -m "feat: log per-phase timing summary at step completion"
+```
+
+---
+
+### Task 5: CsvItemWriter open/close lifecycle
+
+**Files:**
+- Modify: `src/item/csv/csv_writer.rs` (the `impl ItemWriter<O> for CsvItemWriter` block, after `flush` at `:197-204`)
+- Test: `src/item/csv/csv_writer.rs` inline `#[cfg(test)] mod tests`
+
+**Interfaces:**
+- Consumes: the existing `CsvItemWriter::flush` (`csv_writer.rs:197`).
+- Produces: `open`/`close` on `CsvItemWriter`, `close` delegating to `flush`.
+
+**Why:** `CsvItemWriter` implements only `write` and `flush`, inheriting the no-op `open`/`close` defaults from `ItemWriter` (`item.rs:204`, `:220`). `JsonItemWriter` and `XmlItemWriter` both flush in `close` (`json_writer.rs:174`, `xml_writer.rs:144`); CSV is the outlier. Today the per-chunk `flush()` at `step.rs:845` is the only thing guaranteeing CSV rows reach disk before the job ends — `csv::Writer` does flush on `Drop`, but that runs after `job.run()` returns and silently discards the error. This is a robustness fix on its own merits, and it is the precondition for ever making the per-chunk flush optional.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the existing inline `mod tests` in `src/item/csv/csv_writer.rs` (it starts at `csv_writer.rs:494` — note that `.claude/rules/02-unit-tests.md` still lists this file as having no tests, which is stale):
+
+```rust
+#[test]
+fn should_flush_pending_rows_on_close() {
+    #[derive(Serialize)]
+    struct Row {
+        name: String,
+        value: u32,
+    }
+
+    let mut buffer = Vec::new();
+    {
+        let writer = CsvItemWriterBuilder::<Row>::new()
+            .has_headers(true)
+            .from_writer(&mut buffer);
+
+        writer
+            .write(&[Row { name: "alpha".to_string(), value: 1 }])
+            .unwrap();
+
+        // close() must make the data durable without relying on Drop
+        ItemWriter::<Row>::close(&writer).unwrap();
+    }
+
+    let output = String::from_utf8(buffer).unwrap();
+    assert!(output.contains("alpha,1"), "close did not flush: {output}");
+}
+
+#[test]
+fn should_return_ok_from_open() {
+    #[derive(Serialize)]
+    struct Row {
+        name: String,
+    }
+
+    let mut buffer = Vec::new();
+    let writer = CsvItemWriterBuilder::<Row>::new().from_writer(&mut buffer);
+
+    assert!(ItemWriter::<Row>::open(&writer).is_ok());
+}
+```
+
+Note the test asserts on `buffer` **inside** a scope that ends before the read, but `close()` is called before the scope ends — that ordering is what proves `close` flushed rather than `Drop`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features --lib item::csv::csv_writer`
+Expected: `should_flush_pending_rows_on_close` FAILS — the default no-op `close` writes nothing, so the buffer is empty at assertion time.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the `impl<O: Serialize, W: Write> ItemWriter<O> for CsvItemWriter<O, W>` block, after `flush`:
+
+```rust
+    /// Prepares the writer. CSV has no header ceremony to emit here — headers are
+    /// written lazily by the underlying `csv::Writer` on the first record — so this
+    /// is an explicit no-op provided for symmetry with the JSON and XML writers.
+    ///
+    /// # Returns
+    /// - `Ok(())` always
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::csv::csv_writer::CsvItemWriterBuilder;
+    /// use spring_batch_rs::core::item::ItemWriter;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct Record { id: u32 }
+    ///
+    /// let mut buffer = Vec::new();
+    /// let writer = CsvItemWriterBuilder::<Record>::new().from_writer(&mut buffer);
+    /// assert!(ItemWriter::<Record>::open(&writer).is_ok());
+    /// ```
+    fn open(&self) -> ItemWriterResult {
+        Ok(())
+    }
+
+    /// Finalizes the CSV output by flushing all buffered records.
+    ///
+    /// Without this, buffered rows would only reach the destination when the
+    /// underlying `csv::Writer` is dropped, which discards any I/O error.
+    ///
+    /// # Returns
+    /// - `Ok(())` if all buffered data was written
+    /// - `Err(BatchError::ItemWriter)` if flushing the underlying writer failed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::csv::csv_writer::CsvItemWriterBuilder;
+    /// use spring_batch_rs::core::item::ItemWriter;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct Record { id: u32 }
+    ///
+    /// let mut buffer = Vec::new();
+    /// {
+    ///     let writer = CsvItemWriterBuilder::<Record>::new().from_writer(&mut buffer);
+    ///     writer.write(&[Record { id: 7 }]).unwrap();
+    ///     ItemWriter::<Record>::close(&writer).unwrap();
+    /// }
+    /// assert!(String::from_utf8(buffer).unwrap().contains('7'));
+    /// ```
+    fn close(&self) -> ItemWriterResult {
+        self.flush()
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib item::csv && cargo test --doc --all-features item::csv`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/csv/csv_writer.rs
+git commit -m "fix: flush CsvItemWriter on close
+
+CsvItemWriter implemented neither open nor close, inheriting the no-op
+defaults, so the per-chunk flush in the step engine was the only thing
+guaranteeing rows reached disk before a job ended."
+```
+
+---
+
+### Task 6: Version bump and documentation sync
+
+**Files:**
+- Modify: `Cargo.toml:3` (version), `CLAUDE.md` (version line)
+- Modify: `../sbrs-docsite/src/content/docs/reference/performance.mdx`
+- Modify: `../sbrs-docsite/src/content/docs/api/item-writer.mdx`
+
+**Interfaces:**
+- Consumes: `StepExecution::phase_summary` (Task 4), `CsvItemWriter::close` (Task 5).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Bump the version**
+
+In `Cargo.toml:3`, change `version = "0.3.6"` to `version = "0.4.0"`.
+
+Adding `pub` fields to `StepExecution`, which is not `#[non_exhaustive]`, breaks downstream struct-literal construction. In practice `StepExecution::new` is the only construction path, but the change is formally breaking.
+
+Also update the `**Version**: 0.3.0` line near the top of `CLAUDE.md` to `0.4.0` — it is already stale.
+
+- [ ] **Step 2: Document the phase breakdown on the docsite**
+
+In `sbrs-docsite/src/content/docs/reference/performance.mdx`, add a section explaining how to read the breakdown. **`.mdx` only — never create a `.md` alongside it, the `.md` would shadow the `.mdx`.**
+
+````mdx
+## Reading the per-phase breakdown
+
+Every chunk-oriented step logs where its time went:
+
+```text
+Step 'load-postgres' 42.3s — read 18.1s (43%) | process 2.4s (6%) | write 21.1s (50%) | flush 0.7s (2%)
+```
+
+The same numbers are available programmatically:
+
+```rust title="reading step metrics"
+let job = JobBuilder::new().start(&step).build();
+job.run()?;
+
+let metrics = job.get_step_execution("load-postgres").unwrap();
+println!("{}", metrics.phase_summary());
+println!("read: {:?}", metrics.read_duration);
+```
+
+Percentages are relative to the step's total duration. The four phases do not sum
+to 100% — the remainder is framework overhead, and a large remainder is itself
+worth investigating.
+
+Timing is recorded once per chunk, not once per item, so the overhead stays
+negligible even on multi-million-row jobs.
+````
+
+- [ ] **Step 3: Document the close() durability contract**
+
+In `sbrs-docsite/src/content/docs/api/item-writer.mdx`, add to the lifecycle section:
+
+```mdx
+`close()` is where file-based writers guarantee durability. `CsvItemWriter`,
+`JsonItemWriter` and `XmlItemWriter` all flush buffered data there. If you
+implement a custom buffered `ItemWriter`, flush in `close()` — do not rely on
+`Drop`, which cannot report an I/O error.
+```
+
+- [ ] **Step 4: Verify everything**
+
+```bash
+make dev
+cargo test --doc --all-features
+cargo clippy --all-features -- -D warnings
+```
+
+Expected: all green. `make dev` runs format, lint and the full test suite (348 inline + 89 integration tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml CLAUDE.md
+git commit -m "chore: bump to 0.4.0 for StepExecution field additions"
+cd ../sbrs-docsite
+git add src/content/docs/reference/performance.mdx src/content/docs/api/item-writer.mdx
+git commit -m "docs: document per-phase step timing and close() durability"
+```
+
+Note: `sbrs-lib` and `sbrs-docsite` are **separate git repositories**, hence the two commits.
+
+---
+
+### Task 7: Run the measurement
+
+**Files:**
+- Read only: `examples/benchmark_csv_postgres_xml.rs`
+- Create: `docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: the measurement table that selects the follow-up work.
+
+- [ ] **Step 1: Run the benchmark at three scales**
+
+Requires Docker (the example uses a PostgreSQL container).
+
+```bash
+cargo run --release --example benchmark_csv_postgres_xml \
+  --features csv,xml,rdbc-postgres 2>&1 | grep "^Step"
+```
+
+Run at **100k, 1M and 10M rows** — check how the example parameterises row count and vary it. Three scales expose non-linear behaviour, such as `LIMIT/OFFSET` pagination degrading at large offsets (which is why keyset pagination exists in the readers).
+
+- [ ] **Step 2: Record the results**
+
+Write `docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md` with one table per scale, one row per step:
+
+```markdown
+| Step | Total | read | process | write | flush | overhead |
+|---|---|---|---|---|---|---|
+| csv-to-postgres | | | | | | |
+| postgres-to-xml | | | | | | |
+| xml-to-postgres | | | | | | |
+```
+
+Record all three steps separately — they have very different profiles and averaging them hides the answer.
+
+- [ ] **Step 3: Apply the decision table**
+
+From the spec, verbatim:
+
+| Observation | Follow-up |
+|---|---|
+| `read` dominates (waiting on PostgreSQL / CSV) | **B** — prefetch page N+1 in the RDBC/ORM readers |
+| `write` dominates (PostgreSQL INSERT) | **B** — write-behind in the RDBC writers |
+| All three phases the same order of magnitude | **A** — stage pipelining; only option that overlaps them |
+| `process` dominates (XML serialisation) | **Neither A nor B** — CPU parallelism (`rayon`), not async |
+| `flush` > 5% | Make the per-chunk flush optional on `StepBuilder` |
+
+State the conclusion explicitly at the end of the results document, then stop. The follow-up work gets its own brainstorm and spec.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md
+git commit -m "docs: record step phase profiling measurements"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| Instrumentation — four fields | Task 1 |
+| Granularity: chunk not item | Tasks 2-3 (wrapper + inline, never per-item) |
+| Attribution points table | Tasks 2 (read, process) and 3 (write, flush) |
+| Reporting — `info!` line + programmatic access | Task 4 |
+| CsvItemWriter lifecycle fix | Task 5 |
+| Non-goal: per-chunk flush untouched | Task 3 Step 3 leaves `step.rs:837-840` and the flush call itself intact |
+| Measurement protocol — 3 scales, 3 steps | Task 7 |
+| Decision table | Task 7 Step 3 |
+| Semver 0.4.0 | Task 6 Step 1 |
+| Testing — 4 step tests + 2 csv tests | Tasks 1-5 (6 step-level tests written, exceeding the spec's 4) |
+| Documentation sync | Task 6 |
+
+No gaps.
+
+**Placeholder scan:** no TBD/TODO, no "add error handling", no "similar to Task N". Every code step contains the actual code. The only intentionally blank content is the results table in Task 7, which is a data-collection form, not a placeholder.
+
+**Type consistency:** `read_duration` / `process_duration` / `write_duration` / `flush_duration` are named identically in Tasks 1, 2, 3, 4, 6 and 7. `phase_summary()` is defined in Task 4 and referenced in Task 6 with the same name and `-> String` signature. `read_chunk_inner` / `process_chunk_inner` are introduced in Task 2 and referenced nowhere else. `sample_car()` is defined in Task 2 and reused in Task 3.

--- a/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
+++ b/docs/superpowers/plans/2026-08-03-step-phase-profiling.md
@@ -820,8 +820,12 @@ Requires Docker (the example uses a PostgreSQL container).
 
 ```bash
 cargo run --release --example benchmark_csv_postgres_xml \
-  --features csv,xml,rdbc-postgres 2>&1 | grep "^Step"
+  --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
 ```
+
+The benchmark prints the breakdown itself on stderr via `phase_summary()`. Do not rely on the
+engine's `info!` line: `env_logger` defaults to level `error` when `RUST_LOG` is unset, so it is
+suppressed, and its `[timestamp LEVEL target]` prefix defeats an anchored `^Step` pattern anyway.
 
 Run at **100k, 1M and 10M rows** — check how the example parameterises row count and vary it. Three scales expose non-linear behaviour, such as `LIMIT/OFFSET` pagination degrading at large offsets (which is why keyset pagination exists in the readers).
 

--- a/docs/superpowers/specs/2026-08-03-step-phase-profiling-design.md
+++ b/docs/superpowers/specs/2026-08-03-step-phase-profiling-design.md
@@ -1,0 +1,238 @@
+# Step Phase Profiling Design
+
+**Date:** 2026-08-03
+**Branch:** feat-step-phase-profiling
+**Status:** Approved
+
+## Summary
+
+Add per-phase timing (`read` / `process` / `write` / `flush`) to `StepExecution`, report it at
+step completion, and fix the `CsvItemWriter` lifecycle gap that the timing work exposes.
+
+This is step 0 of a performance investigation. The motivating question was whether to migrate
+the crate to an async API for throughput. The answer cannot be settled without knowing where
+time is actually spent today, and no such measurement exists: there is no `benches/` directory,
+no criterion dependency, and `StepExecution` counts items but times nothing below the step level.
+
+---
+
+## Background: why measurement comes first
+
+The crate is often described as "fully synchronous", but that is a facade. `tokio` is a
+**non-optional** dependency with `features = ["full"]` (`Cargo.toml:37`), and twelve sites bridge
+sync to async:
+
+```rust
+// src/item/rdbc/postgres_reader.rs:109
+tokio::task::block_in_place(|| {
+    tokio::runtime::Handle::current().block_on(async { ... })
+})
+```
+
+Sites: the three RDBC readers and three RDBC writers, the ORM reader and writer, and the four S3
+tasklets.
+
+Converting the core traits to `async fn` would **not** improve throughput on its own, and would
+likely hurt it:
+
+- `ChunkOrientedStep` holds `&'a dyn ItemReader<I>` (`step.rs:594`) and `JobInstance` holds
+  `Vec<&'a dyn Step>` (`job.rs:105`). `async fn` in traits is not dyn-compatible, so preserving
+  this design requires `#[async_trait]`, which boxes a future **per call**. `read()` is called
+  once per item — 10M heap allocations on the reference benchmark.
+- The alternative (generic traits returning `impl Future`) breaks `Vec<&dyn Step>` and therefore
+  heterogeneous job composition.
+- A chunk pipeline is sequential by construction: `read → process → write → read`. Async only
+  buys throughput where it enables **overlap**, which is a separate design decision that does not
+  require changing the trait signatures.
+
+The real throughput levers are therefore (A) pipelining the three phases across stages so cost
+becomes `max(read, process, write)` instead of their sum, or (B) adding concurrency inside the
+adapters (prefetch page N+1, write-behind). Choosing between them requires knowing the phase
+breakdown. Hence this spec.
+
+---
+
+## Instrumentation
+
+Four fields added to `StepExecution` (`src/core/step.rs:331-359`):
+
+```rust
+pub read_duration: Duration,
+pub process_duration: Duration,
+pub write_duration: Duration,
+pub flush_duration: Duration,
+```
+
+All initialised to `Duration::ZERO` in `StepExecution::new` (`step.rs:380-396`). `Instant` and
+`Duration` are already imported in this module.
+
+### Granularity: chunk, not item
+
+Timing wraps the loop inside `read_chunk` / `process_chunk` / `write_chunk`, **not** each
+individual `reader.read()` or `processor.process()` call.
+
+On 10M rows with `chunk_size = 1000` this is 10,000 measurements instead of 10,000,000. Timing
+each item would add roughly 20-30 ns per call — about 0.3 s of pure `Instant::now()` overhead on
+the reference benchmark, which would contaminate the very numbers being collected.
+
+### Attribution points
+
+| Field | Location | Wraps |
+|---|---|---|
+| `read_duration` | `read_chunk`, `step.rs:729-772` | the inner `loop` calling `self.reader.read()` |
+| `process_duration` | `process_chunk`, `step.rs:785-817` | the per-item `self.processor.process(item)` loop |
+| `write_duration` | `write_chunk`, `step.rs:842` | `self.writer.write(processed_items)` only |
+| `flush_duration` | `write_chunk`, `step.rs:845` | `self.writer.flush()` only |
+
+`flush` is measured separately from `write` deliberately: it is what quantifies the cost of the
+per-chunk flush discussed below.
+
+The early return for empty chunks (`step.rs:837-840`) records nothing, since no writer call is
+made.
+
+---
+
+## Reporting
+
+An `info!` line emitted at the end of `ChunkOrientedStep::execute`, near the existing timing
+assignment at `step.rs:659-661`:
+
+```
+Step 'load-postgres' 42.3s — read 18.1s (43%) | process 2.4s (6%) | write 21.1s (50%) | flush 0.7s (2%)
+```
+
+Percentages are relative to the step's total `duration`. The residual (total minus the four
+phases) is framework overhead and is expected to be small; a large residual is itself a finding.
+
+Programmatic access already exists through `JobInstance::get_step_execution(&self, name: &str)`
+(`job.rs:213-215`), which returns a cloned `StepExecution` — the new fields come along for free.
+
+---
+
+## CsvItemWriter lifecycle fix
+
+`CsvItemWriter` implements only `write` (`csv_writer.rs:133`) and `flush` (`csv_writer.rs:197`).
+It does **not** implement `open` or `close`, so it inherits the no-op defaults from
+`ItemWriter` (`item.rs:204`, `item.rs:220`).
+
+`JsonItemWriter` and `XmlItemWriter` both flush in `close()` (`json_writer.rs:174`,
+`xml_writer.rs:144`). CSV is the outlier.
+
+Consequence: the per-chunk `flush()` at `step.rs:845` is currently the **only** thing guaranteeing
+CSV rows reach disk before the job ends. (`csv::Writer` does flush in its `Drop` impl, but that
+runs after `job.run()` returns and silently discards errors.) Removing the per-chunk flush without
+fixing this would cause silent data loss.
+
+Fix: implement `close()` on `CsvItemWriter`, delegating to the existing `flush()`. `open()` is
+implemented as an explicit no-op returning `Ok(())` for symmetry with the other file writers.
+
+This is a robustness fix that stands on its own merits, independent of the profiling work.
+
+---
+
+## Explicit non-goals
+
+**No behavioural change to the engine in this spec.** In particular, the per-chunk `flush()` at
+`step.rs:845` stays exactly as it is. It is measured, not modified. Deciding whether to make it
+optional is downstream of the numbers this work produces.
+
+No async conversion, no pipelining, no adapter concurrency. Those are separate specs, gated on the
+decision table below.
+
+---
+
+## Measurement protocol
+
+Target: `examples/benchmark_csv_postgres_xml.rs` — already `#[tokio::main]`, one job with three
+steps (CSV → PostgreSQL, PostgreSQL → XML, XML → PostgreSQL), `chunk_size = 1000`, pool size 10.
+
+Run at three scales — **100k / 1M / 10M rows** — to expose non-linear behaviour (for example
+`LIMIT/OFFSET` pagination degrading quadratically at large offsets, which is why keyset pagination
+exists in the readers).
+
+Record the four-phase breakdown for **each of the three steps** separately; they have very
+different profiles and averaging them would hide the answer.
+
+---
+
+## Decision table
+
+Fixed in advance so the numbers, not intuition, select the follow-up work.
+
+| Observation | Follow-up |
+|---|---|
+| `read` dominates (waiting on PostgreSQL / CSV) | **B** — prefetch page N+1 in the RDBC/ORM readers |
+| `write` dominates (PostgreSQL INSERT) | **B** — write-behind in the RDBC writers |
+| All three phases the same order of magnitude | **A** — stage pipelining; only option that overlaps them |
+| `process` dominates (XML serialisation) | **Neither A nor B** — CPU parallelism (`rayon`), not async |
+| `flush` > 5% | Make the per-chunk flush optional on `StepBuilder` |
+
+The fourth row matters: there is a plausible outcome where async answers nothing, and it is
+cheaper to discover that now.
+
+---
+
+## Semver
+
+Adding `pub` fields to `StepExecution`, which is not `#[non_exhaustive]`, breaks any downstream
+struct-literal construction. In practice `StepExecution::new` is the only construction path, but
+the change is formally breaking — target **0.4.0**.
+
+---
+
+## Testing
+
+Inline `#[cfg(test)]` in `src/core/step.rs`, following `.claude/rules/02-unit-tests.md`:
+
+- `should_record_nonzero_read_duration_after_step` — mock reader with a deliberate delay, assert
+  `read_duration > Duration::ZERO`.
+- `should_attribute_duration_to_the_correct_phase` — a slow mock **writer** with fast reader and
+  processor; assert `write_duration` exceeds both `read_duration` and `process_duration`.
+- `should_record_flush_duration_separately_from_write` — mock writer where `flush` sleeps and
+  `write` does not; assert both are non-zero and distinct.
+- `should_leave_durations_at_zero_for_empty_chunk` — reader returning `None` immediately; assert
+  `write_duration == Duration::ZERO` (the empty-chunk early return skips the writer).
+
+The existing `mock!` blocks at `step.rs:1454-1478` (`MockTestItemReader`, `MockTestProcessor`,
+`MockTestItemWriter`) are reused; no new mocking infrastructure is needed.
+
+Inline `#[cfg(test)]` in `src/item/csv/csv_writer.rs`:
+
+- `should_flush_pending_rows_on_close` — write rows, call `close()`, assert the underlying buffer
+  contains them **without** relying on drop.
+- `should_return_ok_from_open` — assert the no-op contract.
+
+---
+
+## Documentation sync
+
+Per `.claude/rules/04-documentation.md` and the mandatory website-sync rule in `CLAUDE.md`:
+
+- Rustdoc on the four new `StepExecution` fields, including the unit of measurement and the fact
+  that they are cumulative across chunks.
+- Rustdoc on `CsvItemWriter::open` / `close`.
+- `sbrs-docsite/src/content/docs/reference/performance.mdx` — document the new phase breakdown and
+  how to read the step summary log. **`.mdx` only, never `.md`.**
+- `sbrs-docsite/src/content/docs/api/item-writer.mdx` — note that `close()` is where file writers
+  guarantee durability.
+
+---
+
+## Verification
+
+```bash
+make dev                                    # format, lint, test
+cargo test --all-features                   # 348 inline + 89 integration tests
+cargo test --doc --all-features             # ~247 doc blocks still compile
+cargo clippy --all-features -- -D warnings  # zero-warning policy
+```
+
+End-to-end, with Docker running:
+
+```bash
+cargo run --release --example benchmark_csv_postgres_xml \
+  --features csv,xml,rdbc-postgres 2>&1 | grep "^Step"
+```
+
+Expected: three step summary lines, one per step, with the four phases summing to approximately
+the reported step duration.

--- a/docs/superpowers/specs/2026-08-03-step-phase-profiling-design.md
+++ b/docs/superpowers/specs/2026-08-03-step-phase-profiling-design.md
@@ -231,8 +231,20 @@ End-to-end, with Docker running:
 
 ```bash
 cargo run --release --example benchmark_csv_postgres_xml \
-  --features csv,xml,rdbc-postgres 2>&1 | grep "^Step"
+  --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
 ```
 
-Expected: three step summary lines, one per step, with the four phases summing to approximately
-the reported step duration.
+Expected: three summary lines, one per step, of the shape
+
+```text
+Step 'csv-to-postgres' 42.3s — read 18.1s (43%) | process 2.4s (6%) | write 21.1s (50%) | flush 0.7s (2%)
+```
+
+with the four phases summing to somewhat less than the reported step duration (see the residual
+note above).
+
+The benchmark prints these itself, on stderr, via `StepExecution::phase_summary()`. Do **not**
+rely on the `info!` summary the engine emits at step completion: `env_logger` defaults to level
+`error` when `RUST_LOG` is unset, so that record is suppressed, and when it is enabled the
+`[timestamp LEVEL target]` prefix means an anchored `^Step` pattern will never match. To see the
+engine's own log line instead, run with `RUST_LOG=info`.

--- a/docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md
+++ b/docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md
@@ -1,0 +1,136 @@
+# Step Phase Profiling — Results
+
+**Date:** 2026-08-03
+**Branch:** feat-step-phase-profiling
+**Status:** Measured
+
+Execution of Task 7 of `2026-08-03-step-phase-profiling.md`, against the decision table in
+`2026-08-03-step-phase-profiling-design.md`.
+
+## Environment
+
+- PostgreSQL 15.18 (aarch64) in an Apple Container, port published to `127.0.0.1:5432`.
+- Benchmark: `examples/benchmark_csv_postgres_xml`, release build, chunk size 1 000, pool size 10.
+- Pipeline: CSV → PostgreSQL → XML → PostgreSQL, three steps, `TRUNCATE` between runs.
+- `transaction_id VARCHAR(36) PRIMARY KEY`; step 2's reader uses **keyset** pagination
+  (`with_keyset`), page size 1 000.
+
+Note: connecting to the container's own IP (`192.168.64.4`) failed with `No route to host`
+from the benchmark binary, while `ping` and `nc` reached that same address and port. Publishing
+the port to `127.0.0.1` works. The underlying cause was not diagnosed.
+
+## Measurements
+
+### 100k rows
+
+| Step | Total | read | process | write | flush |
+|---|---|---|---|---|---|
+| csv-to-postgres | 0.5s | 9% | 0% | **90%** | 0% |
+| postgres-to-xml | 0.2s | **66%** | 0% | 31% | 0% |
+| xml-to-postgres-import | 0.7s | 29% | 0% | **71%** | 0% |
+
+### 1M rows
+
+| Step | Total | read | process | write | flush |
+|---|---|---|---|---|---|
+| csv-to-postgres | 6.0s | 0.9s (15%) | 0.0s (1%) | **4.9s (82%)** | 0.0s (0%) |
+| postgres-to-xml | 4.0s | **3.3s (83%)** | 0.0s (0%) | 0.6s (16%) | 0.0s (0%) |
+| xml-to-postgres-import | 7.4s | 2.3s (32%) | 0.0s (0%) | **5.0s (67%)** | 0.0s (0%) |
+
+### 10M rows
+
+| Step | Total | read | process | write | flush | residual | throughput |
+|---|---|---|---|---|---|---|---|
+| csv-to-postgres | 57.6s | 8.8s (15%) | 0.5s (1%) | **47.3s (82%)** | 0.0s (0%) | 1.0s (2%) | 173 569 rec/s |
+| postgres-to-xml | 30.8s | **24.2s (78%)** | 0.1s (0%) | 6.2s (20%) | 0.0s (0%) | 0.3s (1%) | 324 474 rec/s |
+| xml-to-postgres-import | 74.0s | 24.5s (33%) | 0.1s (0%) | **48.9s (66%)** | 0.0s (0%) | 0.5s (1%) | 135 166 rec/s |
+
+Total wall-clock at 10M, including CSV generation: **164.2s**.
+
+The residual — everything outside the four timers — is 1-2%, confirming the instrumentation
+accounts for essentially all of each step's time.
+
+## Scaling
+
+Growth factor per 10× increase in rows:
+
+| Step | 100k → 1M | 1M → 10M |
+|---|---|---|
+| csv-to-postgres | ×12.0 | ×9.6 |
+| postgres-to-xml | ×20.0 | ×7.7 |
+| xml-to-postgres-import | ×10.6 | ×10.0 |
+
+**No super-linear degradation.** The ×20 on step 2 between 100k and 1M looked alarming, but the
+1M → 10M factor of ×7.7 is *sub*-linear, which rules out a quadratic effect. The 100k run is
+simply too short (0.2s) to be a reliable baseline — warm-up and cache effects dominate at that
+size. Keyset pagination scales as intended.
+
+Phase proportions are stable between 1M and 10M (step 1 write: 82% → 82%; step 3 write:
+67% → 66%), so the measurements are reproducible.
+
+## Decision table applied
+
+| Observation | Reading | Follow-up |
+|---|---|---|
+| `read` dominates | step 2, 78% | **B** — prefetch page N+1 |
+| `write` dominates | steps 1 and 3, 82% / 66% | **B** — write-behind |
+| All three phases same order | never — one phase always dominates | A not indicated |
+| `process` dominates | never — 0-1% everywhere | `rayon` ruled out |
+| `flush` > 5% | never — 0% everywhere | **leave the per-chunk flush alone** |
+
+**Verdict: option B — concurrency inside the adapters. Not an async trait migration.**
+
+## Analysis
+
+**The async trait migration is not justified by these numbers.** Time is spent waiting on
+PostgreSQL and on file I/O. Making `read()` and `write()` async removes none of that waiting —
+it changes who waits. What removes it is *overlapping* the waits, which needs no change to the
+trait signatures. The `#[async_trait]` cost quantified in the design doc (one boxed future per
+`read()` call — 10M allocations here) would be paid for nothing.
+
+**`process` is negligible, which collapses the case for option A.** Stage pipelining was meant
+to turn `read + process + write` into `max(read, process, write)`. With `process` at ~0, the
+three-stage pipeline degenerates into a two-stage read ‖ write overlap — exactly what option B
+achieves adapter-locally, without touching the engine and without the `Send` bounds A would
+require on the trait objects.
+
+Theoretical ceiling for perfect read/write overlap at 10M:
+
+| Step | Now | Overlapped `max(read, write)` | Gain |
+|---|---|---|---|
+| csv-to-postgres | 57.6s | 47.3s | 18% |
+| postgres-to-xml | 30.8s | 24.2s | 21% |
+| xml-to-postgres-import | 74.0s | 48.9s | 34% |
+| **Total** | **162.4s** | **120.4s** | **26%** |
+
+**The larger prize is underneath that ceiling.** Overlap caps out at 26% because the floor of
+each step becomes its dominant phase — and for steps 1 and 3, that floor is PostgreSQL write
+time: 47.3s and 48.9s for 10M rows, about 210k rows/s. The writer currently issues its batched
+`INSERT`s **sequentially**, one chunk at a time, even though the pool holds 10 connections.
+Spreading chunk writes across several connections concurrently could cut the dominant phase
+itself rather than merely hiding it behind the others.
+
+That is a bigger change than prefetching: it affects write ordering, error attribution, and how
+`skip_limit` accounts for a failed chunk. It should be brainstormed on its own rather than
+folded into a prefetch change.
+
+## The flush question, settled
+
+`flush_duration` is **0% on all three steps at all three scales**. The design doc's threshold for
+making the per-chunk flush optional was 5%.
+
+This is consistent with the code: the PostgreSQL writers inherit the trait's no-op `flush()`
+(`ItemWriter::flush` default), and step 2's `XmlItemWriter`, which does implement a real flush,
+costs nothing because its `BufWriter` has already streamed the data out as its 8 KB buffer
+filled.
+
+**Recommendation: leave the per-chunk flush exactly as it is.** Removing it would trade a
+measured gain of zero for a real loss of crash resilience.
+
+## Recommended next steps
+
+1. **Prefetch in the RDBC/ORM readers** — biggest single win on step 2 (78% read).
+2. **Write-behind in the RDBC writers** — steps 1 and 3.
+3. **Then, separately: concurrent chunk writes.** This is where the remaining factor lives, and
+   it needs its own design discussion because of the ordering and error-handling implications.
+4. **Do not** migrate the traits to async. **Do not** add `rayon`. **Do not** touch the flush.

--- a/examples/benchmark_csv_postgres_xml.rs
+++ b/examples/benchmark_csv_postgres_xml.rs
@@ -23,6 +23,16 @@
 //! ```
 //!
 //! Set DATABASE_URL env var to override the default connection string.
+//!
+//! Set TOTAL_RECORDS to run at a different scale (defaults to 10 million):
+//!
+//! ```bash
+//! TOTAL_RECORDS=100000 cargo run --release --example benchmark_csv_postgres_xml \
+//!   --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
+//! ```
+//!
+//! Each step prints its per-phase timing breakdown (read / process / write / flush)
+//! on stderr via `StepExecution::phase_summary()`.
 
 use serde::{Deserialize, Serialize};
 use spring_batch_rs::{
@@ -111,7 +121,19 @@ impl ItemProcessor<Transaction, Transaction> for TransactionProcessor {
 
 const CURRENCIES: [&str; 3] = ["USD", "EUR", "GBP"];
 const STATUSES: [&str; 4] = ["PENDING", "COMPLETED", "FAILED", "CANCELLED"];
-const TOTAL_RECORDS: u64 = 10_000_000;
+const DEFAULT_TOTAL_RECORDS: u64 = 10_000_000;
+
+/// Number of rows to generate, overridable with `TOTAL_RECORDS` so the benchmark can be
+/// run at several scales — useful for spotting non-linear behaviour such as `LIMIT/OFFSET`
+/// pagination degrading at large offsets.
+///
+/// Falls back to [`DEFAULT_TOTAL_RECORDS`] when unset or unparseable.
+fn total_records() -> u64 {
+    env::var("TOTAL_RECORDS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_TOTAL_RECORDS)
+}
 
 /// Generates a CSV file with `count` random financial transaction rows.
 ///
@@ -379,14 +401,15 @@ async fn main() -> Result<(), BatchError> {
 
     // 4. Total wall time includes CSV generation
     let t_total = Instant::now();
+    let total_records = total_records();
 
     // 5. Generate CSV
     eprintln!(
         "[Generate] Writing {} rows to {} …",
-        TOTAL_RECORDS, csv_path
+        total_records, csv_path
     );
     let t_gen = Instant::now();
-    generate_csv(&csv_path, TOTAL_RECORDS)?;
+    generate_csv(&csv_path, total_records)?;
     eprintln!("[Generate] Done in {:.1}s", t_gen.elapsed().as_secs_f64());
     eprintln!();
 
@@ -523,10 +546,10 @@ async fn main() -> Result<(), BatchError> {
         "║  Total wall-clock time   : {:.1}s  (incl. CSV generation)",
         total_secs
     );
-    eprintln!("║  Records processed       : {}", TOTAL_RECORDS);
+    eprintln!("║  Records processed       : {}", total_records);
     eprintln!(
         "║  Average throughput      : {:.0} rec/s",
-        TOTAL_RECORDS as f64 / total_secs
+        total_records as f64 / total_secs
     );
     eprintln!("╚══════════════════════════════════════════════════════════╝");
     eprintln!();

--- a/examples/benchmark_csv_postgres_xml.rs
+++ b/examples/benchmark_csv_postgres_xml.rs
@@ -502,6 +502,9 @@ async fn main() -> Result<(), BatchError> {
             secs,
             exec.write_count as f64 / secs
         );
+        // Printed directly rather than relying on the `info!` summary, which is
+        // suppressed unless a logger is initialised at info level.
+        eprintln!("{}", exec.phase_summary());
         if exec.read_error_count > 0 || exec.write_error_count > 0 {
             eprintln!(
                 "[Step {}] WARNING: {} read errors, {} write errors skipped",

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -356,13 +356,20 @@ pub struct StepExecution {
     pub filter_count: usize,
     /// Number of errors encountered during writing
     pub write_error_count: usize,
-    /// Cumulative time spent inside `ItemReader::read` calls, summed across all chunks
+    /// Cumulative time spent in the read phase across all chunks. Covers the whole
+    /// per-chunk read loop, including the framework's buffering, not just `ItemReader::read`.
+    /// Only chunk-oriented steps populate this; tasklet steps leave it at zero.
     pub read_duration: Duration,
-    /// Cumulative time spent inside `ItemProcessor::process` calls, summed across all chunks
+    /// Cumulative time spent in the process phase across all chunks. Covers the whole
+    /// per-chunk process loop, including collecting the results, not just `ItemProcessor::process`.
+    /// Only chunk-oriented steps populate this; tasklet steps leave it at zero.
     pub process_duration: Duration,
-    /// Cumulative time spent inside `ItemWriter::write` calls, summed across all chunks
+    /// Cumulative time spent in `ItemWriter::write` across all chunks, excluding the flush
+    /// that follows it. Only chunk-oriented steps populate this; tasklet steps leave it at zero.
     pub write_duration: Duration,
-    /// Cumulative time spent inside `ItemWriter::flush` calls, summed across all chunks
+    /// Cumulative time spent in `ItemWriter::flush` across all chunks, measured separately
+    /// from [`StepExecution::write_duration`] so the cost of flushing once per chunk can be
+    /// quantified. Only chunk-oriented steps populate this; tasklet steps leave it at zero.
     pub flush_duration: Duration,
 }
 
@@ -413,8 +420,13 @@ impl StepExecution {
     /// When `duration` is `None` or zero — for instance before the step has run —
     /// every percentage is reported as `0%` rather than `NaN`.
     ///
-    /// The four phases will not sum to exactly 100%: the remainder is framework
-    /// overhead. A large remainder is itself a useful signal.
+    /// The four phases will not sum to exactly 100%. The remainder holds the writer's
+    /// `open()` and `close()` calls — which is where the CSV, JSON and XML writers perform
+    /// their final flush — the teardown of each processed chunk, and the framework's own
+    /// bookkeeping. A large remainder is itself a useful signal.
+    ///
+    /// Only chunk-oriented steps populate the four phase fields. Calling this on a tasklet
+    /// step's execution yields a line whose phases all read `0.0s (0%)`.
     ///
     /// # Examples
     ///

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -317,6 +317,13 @@ impl<'a> TaskletBuilder<'a> {
 /// StepExecution tracks all relevant information about a step's execution,
 /// including timing, item counts, error counts, and current status.
 ///
+/// # Construction
+///
+/// This type is `#[non_exhaustive]`, so it cannot be built with a struct literal from
+/// outside the crate — use [`StepExecution::new`]. Fields stay public and freely
+/// readable; the attribute exists so that new metrics can be added in a minor release
+/// rather than a breaking one.
+///
 /// # Examples
 ///
 /// ```rust
@@ -329,6 +336,7 @@ impl<'a> TaskletBuilder<'a> {
 /// assert_eq!(step_execution.filter_count, 0);
 /// ```
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct StepExecution {
     /// Unique identifier for this step instance
     pub id: Uuid,

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -874,10 +874,19 @@ impl<I, O> ChunkOrientedStep<'_, I, O> {
             return Ok(());
         }
 
-        match self.writer.write(processed_items) {
+        let write_start = Instant::now();
+        let write_result = self.writer.write(processed_items);
+        step_execution.write_duration += write_start.elapsed();
+
+        match write_result {
             Ok(()) => {
                 step_execution.write_count += processed_items.len();
-                Self::manage_error(self.writer.flush());
+
+                let flush_start = Instant::now();
+                let flush_result = self.writer.flush();
+                step_execution.flush_duration += flush_start.elapsed();
+                Self::manage_error(flush_result);
+
                 Ok(())
             }
             Err(error) => {
@@ -3430,5 +3439,129 @@ mod tests {
             step_execution.read_duration,
             step_execution.process_duration
         );
+    }
+
+    #[test]
+    fn should_record_flush_duration_separately_from_write() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            counter += 1;
+            if counter > 2 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| Ok(()));
+        writer.expect_flush().returning(|| {
+            std::thread::sleep(Duration::from_millis(30));
+            Ok(())
+        });
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("flush-timing")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("flush-timing");
+        step.execute(&mut step_execution).unwrap();
+
+        assert!(
+            step_execution.flush_duration >= Duration::from_millis(30),
+            "flush_duration should capture the sleeping flush, got {:?}",
+            step_execution.flush_duration
+        );
+        assert!(
+            step_execution.flush_duration > step_execution.write_duration,
+            "a slow flush must not be attributed to write: flush={:?} write={:?}",
+            step_execution.flush_duration,
+            step_execution.write_duration
+        );
+    }
+
+    #[test]
+    fn should_attribute_duration_to_the_correct_phase() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            counter += 1;
+            if counter > 3 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| {
+            std::thread::sleep(Duration::from_millis(50));
+            Ok(())
+        });
+        writer.expect_flush().returning(|| Ok(()));
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("phase-attribution")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("phase-attribution");
+        step.execute(&mut step_execution).unwrap();
+
+        assert!(
+            step_execution.write_duration > step_execution.read_duration,
+            "slow writer should dominate: write={:?} read={:?}",
+            step_execution.write_duration,
+            step_execution.read_duration
+        );
+        assert!(
+            step_execution.write_duration > step_execution.process_duration,
+            "slow writer should dominate: write={:?} process={:?}",
+            step_execution.write_duration,
+            step_execution.process_duration
+        );
+    }
+
+    #[test]
+    fn should_leave_write_duration_at_zero_for_empty_chunk() {
+        let mut reader = MockTestItemReader::default();
+        reader.expect_read().returning(|| Ok(None));
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("empty-chunk")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("empty-chunk");
+        step.execute(&mut step_execution).unwrap();
+
+        assert_eq!(
+            step_execution.write_duration,
+            Duration::ZERO,
+            "the empty-chunk early return skips the writer entirely"
+        );
+        assert_eq!(step_execution.flush_duration, Duration::ZERO);
     }
 }

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -356,6 +356,14 @@ pub struct StepExecution {
     pub filter_count: usize,
     /// Number of errors encountered during writing
     pub write_error_count: usize,
+    /// Cumulative time spent inside `ItemReader::read` calls, summed across all chunks
+    pub read_duration: Duration,
+    /// Cumulative time spent inside `ItemProcessor::process` calls, summed across all chunks
+    pub process_duration: Duration,
+    /// Cumulative time spent inside `ItemWriter::write` calls, summed across all chunks
+    pub write_duration: Duration,
+    /// Cumulative time spent inside `ItemWriter::flush` calls, summed across all chunks
+    pub flush_duration: Duration,
 }
 
 impl StepExecution {
@@ -392,6 +400,10 @@ impl StepExecution {
             process_error_count: 0,
             filter_count: 0,
             write_error_count: 0,
+            read_duration: Duration::ZERO,
+            process_duration: Duration::ZERO,
+            write_duration: Duration::ZERO,
+            flush_duration: Duration::ZERO,
         }
     }
 }
@@ -1434,6 +1446,7 @@ mod tests {
     use anyhow::Result;
     use mockall::mock;
     use serde::{Deserialize, Serialize};
+    use std::time::Duration;
 
     use crate::{
         BatchError,
@@ -3296,5 +3309,15 @@ mod tests {
         assert_eq!(step_execution.write_count, 0, "nothing should be written");
 
         Ok(())
+    }
+
+    #[test]
+    fn should_initialize_phase_durations_to_zero() {
+        let step_execution = StepExecution::new("phase-init");
+
+        assert_eq!(step_execution.read_duration, Duration::ZERO);
+        assert_eq!(step_execution.process_duration, Duration::ZERO);
+        assert_eq!(step_execution.write_duration, Duration::ZERO);
+        assert_eq!(step_execution.flush_duration, Duration::ZERO);
     }
 }

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -406,6 +406,53 @@ impl StepExecution {
             flush_duration: Duration::ZERO,
         }
     }
+
+    /// Formats the per-phase timing breakdown as a single human-readable line.
+    ///
+    /// Percentages are relative to the step's total [`StepExecution::duration`].
+    /// When `duration` is `None` or zero — for instance before the step has run —
+    /// every percentage is reported as `0%` rather than `NaN`.
+    ///
+    /// The four phases will not sum to exactly 100%: the remainder is framework
+    /// overhead. A large remainder is itself a useful signal.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use spring_batch_rs::core::step::StepExecution;
+    /// use std::time::Duration;
+    ///
+    /// let mut step_execution = StepExecution::new("load-postgres");
+    /// step_execution.duration = Some(Duration::from_secs(10));
+    /// step_execution.read_duration = Duration::from_secs(5);
+    ///
+    /// let summary = step_execution.phase_summary();
+    /// assert!(summary.contains("read 5.0s (50%)"));
+    /// ```
+    pub fn phase_summary(&self) -> String {
+        let total = self.duration.unwrap_or_default().as_secs_f64();
+        let pct = |d: Duration| -> f64 {
+            if total > 0.0 {
+                d.as_secs_f64() / total * 100.0
+            } else {
+                0.0
+            }
+        };
+
+        format!(
+            "Step '{}' {:.1}s — read {:.1}s ({:.0}%) | process {:.1}s ({:.0}%) | write {:.1}s ({:.0}%) | flush {:.1}s ({:.0}%)",
+            self.name,
+            total,
+            self.read_duration.as_secs_f64(),
+            pct(self.read_duration),
+            self.process_duration.as_secs_f64(),
+            pct(self.process_duration),
+            self.write_duration.as_secs_f64(),
+            pct(self.write_duration),
+            self.flush_duration.as_secs_f64(),
+            pct(self.flush_duration),
+        )
+    }
 }
 
 /// Represents the overall status of a batch job.
@@ -671,6 +718,8 @@ impl<I, O> Step for ChunkOrientedStep<'_, I, O> {
         step_execution.start_time = Some(start_time);
         step_execution.end_time = Some(Instant::now());
         step_execution.duration = Some(start_time.elapsed());
+
+        info!("{}", step_execution.phase_summary());
 
         // Return the step execution details if the step is successful,
         // or an error if the step failed
@@ -1934,6 +1983,41 @@ mod tests {
         assert!(!step_execution.id.is_nil());
 
         Ok(())
+    }
+
+    #[test]
+    fn should_format_phase_summary_with_percentages() {
+        let mut step_execution = StepExecution::new("load-postgres");
+        step_execution.duration = Some(Duration::from_secs(10));
+        step_execution.read_duration = Duration::from_secs(5);
+        step_execution.process_duration = Duration::from_secs(1);
+        step_execution.write_duration = Duration::from_secs(3);
+        step_execution.flush_duration = Duration::from_secs(1);
+
+        let summary = step_execution.phase_summary();
+
+        assert!(summary.contains("load-postgres"), "summary: {summary}");
+        assert!(summary.contains("read 5.0s (50%)"), "summary: {summary}");
+        assert!(summary.contains("process 1.0s (10%)"), "summary: {summary}");
+        assert!(summary.contains("write 3.0s (30%)"), "summary: {summary}");
+        assert!(summary.contains("flush 1.0s (10%)"), "summary: {summary}");
+    }
+
+    #[test]
+    fn should_report_zero_percentages_when_duration_is_unset() {
+        let step_execution = StepExecution::new("never-ran");
+
+        let summary = step_execution.phase_summary();
+
+        assert!(summary.contains("(0%)"), "summary: {summary}");
+        assert!(
+            !summary.contains("NaN"),
+            "division by zero leaked: {summary}"
+        );
+        assert!(
+            !summary.contains("inf"),
+            "division by zero leaked: {summary}"
+        );
     }
 
     #[test]

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -742,6 +742,17 @@ impl<I, O> ChunkOrientedStep<'_, I, O> {
         &self,
         step_execution: &mut StepExecution,
     ) -> Result<(Vec<I>, ChunkStatus), BatchError> {
+        let start = Instant::now();
+        let result = self.read_chunk_inner(step_execution);
+        step_execution.read_duration += start.elapsed();
+        result
+    }
+
+    // timed by the wrapper above
+    fn read_chunk_inner(
+        &self,
+        step_execution: &mut StepExecution,
+    ) -> Result<(Vec<I>, ChunkStatus), BatchError> {
         debug!("Start reading chunk");
 
         let mut read_items = Vec::with_capacity(self.chunk_size as usize);
@@ -795,6 +806,18 @@ impl<I, O> ChunkOrientedStep<'_, I, O> {
     /// - `Ok(Vec<W>)`: Vector of successfully processed items
     /// - `Err(BatchError)`: An error occurred and skip limit was reached
     fn process_chunk(
+        &self,
+        step_execution: &mut StepExecution,
+        read_items: Vec<I>,
+    ) -> Result<Vec<O>, BatchError> {
+        let start = Instant::now();
+        let result = self.process_chunk_inner(step_execution, read_items);
+        step_execution.process_duration += start.elapsed();
+        result
+    }
+
+    // timed by the wrapper above
+    fn process_chunk_inner(
         &self,
         step_execution: &mut StepExecution,
         read_items: Vec<I>,
@@ -1453,7 +1476,7 @@ mod tests {
         core::{
             item::{
                 ItemProcessor, ItemProcessorResult, ItemReader, ItemReaderResult, ItemWriter,
-                ItemWriterResult,
+                ItemWriterResult, PassThroughProcessor,
             },
             step::{StepExecution, StepStatus},
         },
@@ -1518,6 +1541,15 @@ mod tests {
         };
         *i += 1;
         Ok(Some(car))
+    }
+
+    fn sample_car() -> Option<Car> {
+        Some(Car {
+            year: 2024,
+            make: "Renault".to_string(),
+            model: "Zoe".to_string(),
+            description: "electric".to_string(),
+        })
     }
 
     fn mock_process(i: &mut u16, error_at: &[u16]) -> ItemProcessorResult<Car> {
@@ -3319,5 +3351,84 @@ mod tests {
         assert_eq!(step_execution.process_duration, Duration::ZERO);
         assert_eq!(step_execution.write_duration, Duration::ZERO);
         assert_eq!(step_execution.flush_duration, Duration::ZERO);
+    }
+
+    #[test]
+    fn should_record_nonzero_read_duration_after_step() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            std::thread::sleep(Duration::from_millis(20));
+            counter += 1;
+            if counter > 2 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| Ok(()));
+        writer.expect_flush().returning(|| Ok(()));
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("read-timing")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("read-timing");
+        step.execute(&mut step_execution).unwrap();
+
+        assert!(
+            step_execution.read_duration >= Duration::from_millis(40),
+            "expected read_duration to cover 3 sleeping reads, got {:?}",
+            step_execution.read_duration
+        );
+    }
+
+    #[test]
+    fn should_attribute_slow_reads_to_read_duration_not_process() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            std::thread::sleep(Duration::from_millis(30));
+            counter += 1;
+            if counter > 2 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| Ok(()));
+        writer.expect_flush().returning(|| Ok(()));
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("read-attribution")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("read-attribution");
+        step.execute(&mut step_execution).unwrap();
+
+        assert!(
+            step_execution.read_duration > step_execution.process_duration,
+            "a sleeping reader must not have its time attributed to process: read={:?} process={:?}",
+            step_execution.read_duration,
+            step_execution.process_duration
+        );
     }
 }

--- a/src/item/csv/csv_writer.rs
+++ b/src/item/csv/csv_writer.rs
@@ -243,17 +243,34 @@ impl<O: Serialize, W: Write> ItemWriter<O> for CsvItemWriter<O, W> {
     /// use spring_batch_rs::item::csv::csv_writer::CsvItemWriterBuilder;
     /// use spring_batch_rs::core::item::ItemWriter;
     /// use serde::Serialize;
+    /// use std::cell::RefCell;
+    /// use std::io::Write;
+    /// use std::rc::Rc;
     ///
     /// #[derive(Serialize)]
     /// struct Record { id: u32 }
     ///
-    /// let mut buffer = Vec::new();
-    /// {
-    ///     let writer = CsvItemWriterBuilder::<Record>::new().from_writer(&mut buffer);
-    ///     writer.write(&[Record { id: 7 }]).unwrap();
-    ///     ItemWriter::<Record>::close(&writer).unwrap();
+    /// // A sink whose contents stay readable while the writer is still alive,
+    /// // so the example can show that `close` — not `Drop` — did the flushing.
+    /// struct Sink(Rc<RefCell<Vec<u8>>>);
+    /// impl Write for Sink {
+    ///     fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+    ///         self.0.borrow_mut().extend_from_slice(buf);
+    ///         Ok(buf.len())
+    ///     }
+    ///     fn flush(&mut self) -> std::io::Result<()> { Ok(()) }
     /// }
-    /// assert!(String::from_utf8(buffer).unwrap().contains('7'));
+    ///
+    /// let sink = Rc::new(RefCell::new(Vec::new()));
+    /// let writer = CsvItemWriterBuilder::<Record>::new()
+    ///     .from_writer(Sink(Rc::clone(&sink)));
+    ///
+    /// writer.write(&[Record { id: 7 }]).unwrap();
+    /// assert!(sink.borrow().is_empty(), "csv::Writer still holds the row");
+    ///
+    /// ItemWriter::<Record>::close(&writer).unwrap();
+    ///
+    /// assert!(String::from_utf8(sink.borrow().clone()).unwrap().contains('7'));
     /// ```
     fn close(&self) -> ItemWriterResult {
         self.flush()

--- a/src/item/csv/csv_writer.rs
+++ b/src/item/csv/csv_writer.rs
@@ -202,6 +202,62 @@ impl<O: Serialize, W: Write> ItemWriter<O> for CsvItemWriter<O, W> {
             Err(error) => Err(BatchError::ItemWriter(error.to_string())),
         }
     }
+
+    /// Prepares the writer. CSV has no header ceremony to emit here — headers are
+    /// written lazily by the underlying `csv::Writer` on the first record — so this
+    /// is an explicit no-op provided for symmetry with the JSON and XML writers.
+    ///
+    /// # Returns
+    /// - `Ok(())` always
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::csv::csv_writer::CsvItemWriterBuilder;
+    /// use spring_batch_rs::core::item::ItemWriter;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct Record { id: u32 }
+    ///
+    /// let mut buffer = Vec::new();
+    /// let writer = CsvItemWriterBuilder::<Record>::new().from_writer(&mut buffer);
+    /// assert!(ItemWriter::<Record>::open(&writer).is_ok());
+    /// ```
+    fn open(&self) -> ItemWriterResult {
+        Ok(())
+    }
+
+    /// Finalizes the CSV output by flushing all buffered records.
+    ///
+    /// Without this, buffered rows would only reach the destination when the
+    /// underlying `csv::Writer` is dropped, which discards any I/O error.
+    ///
+    /// # Returns
+    /// - `Ok(())` if all buffered data was written
+    /// - `Err(BatchError::ItemWriter)` if flushing the underlying writer failed
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::csv::csv_writer::CsvItemWriterBuilder;
+    /// use spring_batch_rs::core::item::ItemWriter;
+    /// use serde::Serialize;
+    ///
+    /// #[derive(Serialize)]
+    /// struct Record { id: u32 }
+    ///
+    /// let mut buffer = Vec::new();
+    /// {
+    ///     let writer = CsvItemWriterBuilder::<Record>::new().from_writer(&mut buffer);
+    ///     writer.write(&[Record { id: 7 }]).unwrap();
+    ///     ItemWriter::<Record>::close(&writer).unwrap();
+    /// }
+    /// assert!(String::from_utf8(buffer).unwrap().contains('7'));
+    /// ```
+    fn close(&self) -> ItemWriterResult {
+        self.flush()
+    }
 }
 
 /// A builder for creating CSV item writers.
@@ -674,5 +730,47 @@ mod tests {
         let content = fs::read_to_string(&path).unwrap();
         assert!(content.contains("name,value"), "file header missing");
         assert!(content.contains("alpha,1"), "file data missing");
+    }
+
+    #[test]
+    fn should_flush_pending_rows_on_close() {
+        #[derive(Serialize)]
+        struct Row {
+            name: String,
+            value: u32,
+        }
+
+        let mut buffer = Vec::new();
+        {
+            let writer = CsvItemWriterBuilder::<Row>::new()
+                .has_headers(true)
+                .from_writer(&mut buffer);
+
+            writer
+                .write(&[Row {
+                    name: "alpha".to_string(),
+                    value: 1,
+                }])
+                .unwrap();
+
+            // close() must make the data durable without relying on Drop
+            ItemWriter::<Row>::close(&writer).unwrap();
+        }
+
+        let output = String::from_utf8(buffer).unwrap();
+        assert!(output.contains("alpha,1"), "close did not flush: {output}");
+    }
+
+    #[test]
+    fn should_return_ok_from_open() {
+        #[derive(Serialize)]
+        struct Row {
+            name: String,
+        }
+
+        let mut buffer = Vec::new();
+        let writer = CsvItemWriterBuilder::<Row>::new().from_writer(&mut buffer);
+
+        assert!(ItemWriter::<Row>::open(&writer).is_ok());
     }
 }

--- a/src/item/csv/csv_writer.rs
+++ b/src/item/csv/csv_writer.rs
@@ -732,6 +732,21 @@ mod tests {
         assert!(content.contains("alpha,1"), "file data missing");
     }
 
+    /// A `Write` sink whose contents the test can inspect while the writer is still alive.
+    #[derive(Clone)]
+    struct SharedBuffer(std::rc::Rc<std::cell::RefCell<Vec<u8>>>);
+
+    impl std::io::Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.borrow_mut().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
     #[test]
     fn should_flush_pending_rows_on_close() {
         #[derive(Serialize)]
@@ -740,24 +755,30 @@ mod tests {
             value: u32,
         }
 
-        let mut buffer = Vec::new();
-        {
-            let writer = CsvItemWriterBuilder::<Row>::new()
-                .has_headers(true)
-                .from_writer(&mut buffer);
+        let shared = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let writer = CsvItemWriterBuilder::<Row>::new()
+            .has_headers(true)
+            .from_writer(SharedBuffer(std::rc::Rc::clone(&shared)));
 
-            writer
-                .write(&[Row {
-                    name: "alpha".to_string(),
-                    value: 1,
-                }])
-                .unwrap();
+        writer
+            .write(&[Row {
+                name: "alpha".to_string(),
+                value: 1,
+            }])
+            .unwrap();
 
-            // close() must make the data durable without relying on Drop
-            ItemWriter::<Row>::close(&writer).unwrap();
-        }
+        // csv::Writer buffers internally, so nothing has reached the sink yet.
+        assert!(
+            shared.borrow().is_empty(),
+            "expected the row to still be buffered before close, sink already had: {:?}",
+            String::from_utf8_lossy(&shared.borrow())
+        );
 
-        let output = String::from_utf8(buffer).unwrap();
+        ItemWriter::<Row>::close(&writer).unwrap();
+
+        // Read the sink while `writer` is still in scope — Drop has NOT run yet,
+        // so anything visible here was flushed by close() itself.
+        let output = String::from_utf8(shared.borrow().clone()).unwrap();
         assert!(output.contains("alpha,1"), "close did not flush: {output}");
     }
 

--- a/src/item/json/json_writer.rs
+++ b/src/item/json/json_writer.rs
@@ -101,10 +101,8 @@ impl<O: serde::Serialize, W: Write> ItemWriter<O> for JsonItemWriter<O, W> {
                 serde_json::to_string(item).map_err(|e| BatchError::ItemWriter(e.to_string()))
             };
 
-            match result {
-                Ok(json_str) => json_chunk.push_str(&json_str),
-                Err(e) => return Err(e),
-            }
+            let json_str = result?;
+            json_chunk.push_str(&json_str);
 
             if self.use_pretty_formatter {
                 json_chunk.push('\n');

--- a/src/item/json/json_writer.rs
+++ b/src/item/json/json_writer.rs
@@ -101,8 +101,10 @@ impl<O: serde::Serialize, W: Write> ItemWriter<O> for JsonItemWriter<O, W> {
                 serde_json::to_string(item).map_err(|e| BatchError::ItemWriter(e.to_string()))
             };
 
-            let json_str = result?;
-            json_chunk.push_str(&json_str);
+            match result {
+                Ok(json_str) => json_chunk.push_str(&json_str),
+                Err(e) => return Err(e),
+            }
 
             if self.use_pretty_formatter {
                 json_chunk.push('\n');


### PR DESCRIPTION
## Why

The question was whether to migrate the crate to an async API for throughput. It could not be
answered: nothing measured where a step's time actually goes — no `benches/`, no criterion, and
`StepExecution` counted items but timed nothing below step level.

This branch is step 0 of that investigation. It adds the measurement, then uses it.

**Verdict: do not migrate the traits to async.**

## What the measurements show

10M rows, PostgreSQL 15, chunk size 1000:

| Step | Total | read | process | write | flush |
|---|---|---|---|---|---|
| csv-to-postgres | 57.6s | 15% | 1% | **82%** | 0% |
| postgres-to-xml | 30.8s | **78%** | 0% | 20% | 0% |
| xml-to-postgres-import | 74.0s | 33% | 0% | **66%** | 0% |

Residual outside the four timers: 1-2%. Scaling is linear (1M→10M: ×9.6 / ×7.7 / ×10.0).

- **Async traits are not justified.** Time is spent *waiting* on PostgreSQL and file I/O.
  Making `read()`/`write()` async does not remove that waiting, it changes who waits. Removing
  it means *overlapping* the waits, which needs no change to the trait signatures. The
  `#[async_trait]` cost — one boxed future per `read()`, 10M allocations here — would buy
  nothing.
- **`process` is 0-1% everywhere**, which rules out `rayon` and also collapses the case for
  stage pipelining: with no compute phase, a three-stage pipeline degenerates into the
  read‖write overlap that adapter-local concurrency already gives, without requiring `Send`
  bounds on the trait objects.
- **`flush` is 0% at every scale** (threshold for action was 5%). The per-chunk flush stays.

Recommended follow-up: prefetch in the RDBC/ORM readers, write-behind in the writers. Perfect
overlap caps at 26% — underneath sits sequential PostgreSQL writing (~210k rows/s over a
10-connection pool used one chunk at a time), which is the larger prize and needs its own design
discussion.

Full results: `docs/superpowers/specs/2026-08-03-step-phase-profiling-results.md`

## What changed

- `StepExecution` gains `read_duration` / `process_duration` / `write_duration` /
  `flush_duration`, plus `phase_summary()`, logged at step completion.
- Timing is **per chunk, never per item** — 8 clock reads per chunk (~2ms over a 10M run).
  Per-item timing would have added ~0.3s and contaminated the numbers.
- `read_chunk`/`process_chunk` use wrapper shims because `read_chunk` has four early-return
  points; `write_chunk` uses inline timing because `write` and `flush` must be attributed
  separately.
- **Bug fix, independent of the above:** `CsvItemWriter` implemented neither `open()` nor
  `close()`, unlike the JSON and XML writers. I/O errors on the final CSV flush were silently
  swallowed by `csv::Writer`'s `Drop`.
- `StepExecution` is now `#[non_exhaustive]`, so follow-up metrics land in a minor release.
- Benchmark scale is configurable via `TOTAL_RECORDS`, and it prints `phase_summary()` directly
  (the `info!` line is suppressed by `env_logger` unless `RUST_LOG=info`).
- Version 0.4.0 — adding `pub` fields to a non-`#[non_exhaustive]` struct is formally breaking.

## Verification

`cargo test --all-features --lib` (391), `--doc` (240), the six Docker-free integration files,
`clippy --all-features -- -D warnings`, `fmt --check`.

**Not run locally:** the 6 testcontainers integration files (postgres, mysql, mongodb, orm, ftp,
s3) — no Docker-compatible runtime available in the dev environment. CI should be treated as the
first real run of those.

Docs updated in the sibling `sbrs-docsite` repo (commits `c50297a`, `2a9ff41`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)