### PR TITLE
docs: add concurrent RDBC writes design spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Spring Batch RS is a Rust implementation of the Spring Batch framework for building enterprise-grade batch processing applications. It provides chunk-oriented processing, extensible readers/writers, and support for multiple data formats and databases.
 
-**Version**: 0.4.0
+**Version**: 0.5.0
 **Language**: Rust 2024 Edition
 **Documentation**: https://spring-batch-rs.boussekeyt.dev/
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4579,7 +4579,7 @@ dependencies = [
 
 [[package]]
 name = "spring-batch-rs"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spring-batch-rs"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Simon Boussekeyt <sboussekeyt@gmail.com>"]
 license = "MIT OR Apache-2.0"

--- a/docs/superpowers/plans/2026-08-03-concurrent-rdbc-writes.md
+++ b/docs/superpowers/plans/2026-08-03-concurrent-rdbc-writes.md
@@ -1,0 +1,976 @@
+# Concurrent RDBC Writes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the PostgreSQL and MySQL item writers issue several chunk INSERTs concurrently, opt-in via `.with_concurrency(N)`, so the dominant write phase stops being a queue of one.
+
+**Architecture:** The concurrency mechanism lives in one new module, `inflight_writes.rs`, which owns a bounded `JoinSet` and knows nothing about SQL. Each writer keeps building its own query and hands the resulting future to that module. The engine is changed so a failing `close()` fails the step — without this, the final in-flight batch could fail silently.
+
+**Tech Stack:** Rust 2024, `tokio::task::JoinSet`, `sqlx` 0.9, `mockall` (dev), existing helpers in `src/item/rdbc/writer_common.rs`.
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-design.md`.
+- Branch: `feat-concurrent-rdbc-writes` (already created; spec committed as `979aa66`).
+- **Opt-in only.** `with_concurrency(1)` or no call at all must take the *existing code path*, not an equivalent one. Verify by branching on `concurrency <= 1` before any new logic runs.
+- **Scope is PostgreSQL and MySQL.** SQLite warns and stays sequential. SeaORM and MongoDB are untouched.
+- **`flush()` must never drain.** The engine calls it after every chunk (`step.rs:955`); draining there collapses the design back to sequential. Only `close()` drains.
+- Timing/counters: the engine attributes `write_error_count += processed_items.len()` (`step.rs:963`) to the *current* chunk even when the error came from an earlier one. Document, do not try to fix.
+- Version target **0.5.0** — the `close()` change is a behavioural break.
+- Rust 2024, zero-warning clippy (`-D warnings`), `cargo fmt --check` clean.
+- Never `println!`; use `log` macros.
+- Test naming `should_<behaviour>_<condition>`; every test and doc-test asserts something.
+- **`block_in_place` panics on a current-thread runtime.** Every test that exercises the concurrent path must be `#[tokio::test(flavor = "multi_thread")]`.
+
+---
+
+### Task 1: Make a failing close() fail the step
+
+**Files:**
+- Modify: `src/core/step.rs:729` (the `close()` call in `ChunkOrientedStep::execute`)
+- Test: `src/core/step.rs` inline `mod tests`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `ChunkOrientedStep::execute` returns `Err(BatchError::Step(name))` and sets `StepStatus::WriteError` when `writer.close()` fails. Task 4 and Task 5 rely on this to surface the final batch's errors.
+
+**Why first:** every later task depends on this being true. Concurrent writes learn the fate of their last batch only at `close()`; if that error stays a warning, the feature loses data silently.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the inline `mod tests` in `src/core/step.rs`:
+
+```rust
+#[test]
+fn should_fail_the_step_when_close_fails() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        counter += 1;
+        if counter > 2 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| Ok(()));
+    writer.expect_flush().returning(|| Ok(()));
+    writer
+        .expect_close()
+        .returning(|| Err(BatchError::ItemWriter("close failed".to_string())));
+
+    let step = StepBuilder::new("close-fails")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("close-fails");
+    let result = step.execute(&mut step_execution);
+
+    assert!(
+        result.is_err(),
+        "a failing close() must fail the step, otherwise unwritten data is reported as success"
+    );
+    assert_eq!(step_execution.status, StepStatus::WriteError);
+}
+
+#[test]
+fn should_still_succeed_when_close_succeeds() {
+    let mut reader = MockTestItemReader::default();
+    let mut counter = 0u16;
+    reader.expect_read().returning(move || {
+        counter += 1;
+        if counter > 2 { Ok(None) } else { Ok(sample_car()) }
+    });
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let mut writer = MockTestItemWriter::default();
+    writer.expect_open().returning(|| Ok(()));
+    writer.expect_write().returning(|_| Ok(()));
+    writer.expect_flush().returning(|| Ok(()));
+    writer.expect_close().returning(|| Ok(()));
+
+    let step = StepBuilder::new("close-ok")
+        .chunk(10)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let mut step_execution = StepExecution::new("close-ok");
+    assert!(step.execute(&mut step_execution).is_ok());
+    assert_eq!(step_execution.status, StepStatus::Success);
+}
+```
+
+- [ ] **Step 2: Run tests to verify the first fails**
+
+Run: `cargo test --all-features --lib core::step::tests::should_fail_the_step_when_close_fails`
+Expected: FAIL — the step currently returns `Ok` because `manage_error` only warns.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `ChunkOrientedStep::execute`, replace the `close()` line (`step.rs:729`):
+
+```rust
+        Self::manage_error(self.writer.close());
+```
+
+with:
+
+```rust
+        // A failing close() means buffered or in-flight writes never landed.
+        // Treat it as fatal: reporting Success here would hide data loss.
+        let close_result = self.writer.close();
+        if let Err(ref error) = close_result {
+            warn!("Error closing writer: {}", error);
+            step_execution.status = StepStatus::WriteError;
+        }
+```
+
+Leave `Self::manage_error(self.writer.open());` (`step.rs:694`) exactly as it is — `open()` keeps its non-fatal handling, and widening the change serves nothing.
+
+The existing status check at the end of `execute` already turns a non-`Success` status into `Err(BatchError::Step(...))`, so no further change is needed there. Verify that by reading the tail of `execute` before assuming it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib core::step`
+Expected: PASS. If any pre-existing test now fails because it relied on a failing `close()` being ignored, do NOT weaken the new behaviour — report it to the controller, since that test encodes the defect being fixed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/core/step.rs
+git commit -m "fix!: fail the step when ItemWriter::close() fails
+
+close() errors were swallowed by manage_error, so a step could report
+Success after its final flush failed. Behavioural break: a job that
+previously passed with a close error now fails."
+```
+
+---
+
+### Task 2: InflightWrites — the bounded concurrency mechanism
+
+**Files:**
+- Create: `src/item/rdbc/inflight_writes.rs`
+- Modify: `src/item/rdbc/mod.rs` (add `mod inflight_writes;` next to the other private modules at lines 2-20)
+- Test: inline `#[cfg(test)] mod tests` in the new file
+
+**Interfaces:**
+- Consumes: `create_write_error(table: &str, db_name: &str, error: impl Display) -> BatchError` from `writer_common.rs:68`.
+- Produces, used by Tasks 4 and 5:
+  - `pub(crate) struct InflightWrites`
+  - `pub(crate) fn new(limit: usize, table: String, db_name: &'static str) -> InflightWrites`
+  - `pub(crate) fn spawn<F>(&mut self, fut: F) -> Result<(), BatchError> where F: Future<Output = Result<(), sqlx::Error>> + Send + 'static`
+  - `pub(crate) fn harvest(&mut self) -> Result<(), BatchError>`
+  - `pub(crate) fn drain(&mut self) -> Result<(), BatchError>`
+
+**Why its own module:** this mechanism is identical for PostgreSQL and MySQL. Putting it in one place keeps the two writers free of `JoinSet` bookkeeping, and — the real win — it is testable with plain futures, needing no database and no Docker.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/item/rdbc/inflight_writes.rs` with only this test module at first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn ok_after(ms: u64) -> impl std::future::Future<Output = Result<(), sqlx::Error>> + Send + 'static {
+        async move {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            Ok(())
+        }
+    }
+
+    fn fail_after(ms: u64) -> impl std::future::Future<Output = Result<(), sqlx::Error>> + Send + 'static {
+        async move {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            Err(sqlx::Error::PoolClosed)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_overlap_writes_up_to_the_limit() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+
+        let start = Instant::now();
+        for _ in 0..4 {
+            inflight.spawn(ok_after(100)).unwrap();
+        }
+        inflight.drain().unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(300),
+            "4 x 100ms writes with limit 4 should overlap, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_block_when_the_limit_is_reached() {
+        let mut inflight = InflightWrites::new(2, "t".to_string(), "TestDb");
+
+        let start = Instant::now();
+        for _ in 0..4 {
+            inflight.spawn(ok_after(100)).unwrap();
+        }
+        inflight.drain().unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "4 x 100ms writes with limit 2 must serialise into 2 waves, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_surface_error_on_drain() {
+        let mut inflight = InflightWrites::new(4, "orders".to_string(), "TestDb");
+
+        inflight.spawn(ok_after(10)).unwrap();
+        inflight.spawn(fail_after(10)).unwrap();
+
+        let result = inflight.drain();
+
+        assert!(result.is_err(), "drain must surface a failed write");
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("TestDb"),
+            "error should name the database, got: {message}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_report_no_error_when_nothing_was_spawned() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+
+        assert!(inflight.harvest().is_ok());
+        assert!(inflight.drain().is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_not_block_on_harvest() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+        inflight.spawn(ok_after(500)).unwrap();
+
+        let start = Instant::now();
+        let result = inflight.harvest();
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok());
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "harvest must not wait for in-flight tasks, took {:?}",
+            elapsed
+        );
+
+        inflight.drain().unwrap();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Add `mod inflight_writes;` to `src/item/rdbc/mod.rs`, then run:
+`cargo test --all-features --lib item::rdbc::inflight_writes`
+Expected: FAIL to compile — `InflightWrites` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Prepend to `src/item/rdbc/inflight_writes.rs`:
+
+```rust
+//! Bounded concurrency for chunk writes.
+//!
+//! Holds at most `limit` in-flight write tasks. Errors are surfaced when
+//! harvested — on a later call, or at [`InflightWrites::drain`] — never at the
+//! moment the failing write was dispatched.
+
+use std::future::Future;
+
+use tokio::task::JoinSet;
+
+use crate::BatchError;
+use crate::item::rdbc::writer_common::create_write_error;
+
+/// A bounded set of in-flight database writes.
+///
+/// # Implementation Note
+///
+/// `spawn` blocks when the limit is reached; that block *is* the backpressure,
+/// so no separate counter is maintained. `harvest` never blocks, because the
+/// step engine calls `ItemWriter::flush` after every chunk and blocking there
+/// would serialise everything again.
+pub(crate) struct InflightWrites {
+    limit: usize,
+    set: JoinSet<Result<(), sqlx::Error>>,
+    table: String,
+    db_name: &'static str,
+}
+
+impl InflightWrites {
+    pub(crate) fn new(limit: usize, table: String, db_name: &'static str) -> Self {
+        Self {
+            limit: limit.max(1),
+            set: JoinSet::new(),
+            table,
+            db_name,
+        }
+    }
+
+    /// Dispatches a write, first waiting for a slot if the limit is reached.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`] if a *previously* dispatched write
+    /// failed and was harvested while making room.
+    pub(crate) fn spawn<F>(&mut self, fut: F) -> Result<(), BatchError>
+    where
+        F: Future<Output = Result<(), sqlx::Error>> + Send + 'static,
+    {
+        let mut first_error = self.harvest();
+
+        while self.set.len() >= self.limit {
+            let joined = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(self.set.join_next())
+            });
+            match joined {
+                Some(outcome) => {
+                    if let Err(e) = self.interpret(outcome) {
+                        if first_error.is_ok() {
+                            first_error = Err(e);
+                        }
+                    }
+                }
+                None => break,
+            }
+        }
+
+        self.set.spawn(fut);
+        first_error
+    }
+
+    /// Collects results of already-finished writes without waiting.
+    pub(crate) fn harvest(&mut self) -> Result<(), BatchError> {
+        let mut first_error = Ok(());
+        while let Some(outcome) = self.set.try_join_next() {
+            if let Err(e) = self.interpret(outcome) {
+                if first_error.is_ok() {
+                    first_error = Err(e);
+                }
+            }
+        }
+        first_error
+    }
+
+    /// Waits for every in-flight write and returns the first error found.
+    pub(crate) fn drain(&mut self) -> Result<(), BatchError> {
+        let mut first_error = Ok(());
+        loop {
+            let joined = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(self.set.join_next())
+            });
+            match joined {
+                Some(outcome) => {
+                    if let Err(e) = self.interpret(outcome) {
+                        if first_error.is_ok() {
+                            first_error = Err(e);
+                        }
+                    }
+                }
+                None => break,
+            }
+        }
+        first_error
+    }
+
+    fn interpret(
+        &self,
+        outcome: Result<Result<(), sqlx::Error>, tokio::task::JoinError>,
+    ) -> Result<(), BatchError> {
+        match outcome {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(create_write_error(&self.table, self.db_name, e)),
+            Err(join_error) => Err(create_write_error(&self.table, self.db_name, join_error)),
+        }
+    }
+}
+```
+
+Note `limit.max(1)`: a zero limit would make `spawn` loop forever waiting for a slot it can never get.
+
+`writer_common` is a private module, so `create_write_error` is reachable as
+`crate::item::rdbc::writer_common::create_write_error`. If the compiler rejects that path, check
+how the sibling writers import it and match them rather than making the module public.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib item::rdbc::inflight_writes`
+Expected: PASS, 5 tests.
+
+If `should_block_when_the_limit_is_reached` is flaky on a loaded machine, report it rather than loosening the threshold — the assertion is the only proof that bounding works.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/rdbc/inflight_writes.rs src/item/rdbc/mod.rs
+git commit -m "feat: add InflightWrites, a bounded set of in-flight writes"
+```
+
+---
+
+### Task 3: with_concurrency on the builder
+
+**Files:**
+- Modify: `src/item/rdbc/unified_writer_builder.rs` (struct at :98, `new` at :109, and the three `build_*` at :252, :291, :330)
+- Modify: `src/item/rdbc/postgres_writer.rs:43-58` (struct + `new`), `src/item/rdbc/mysql_writer.rs` (same shape)
+- Test: inline `mod tests` in `unified_writer_builder.rs`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces: `RdbcItemWriterBuilder::with_concurrency(self, concurrency: usize) -> Self`, and a `pub(crate) concurrency: usize` field on `PostgresItemWriter<O>` and `MySqlItemWriter<O>`, defaulting to `1`. Tasks 4 and 5 read that field.
+
+**This task adds no behaviour.** The field is carried and defaulted; nothing consumes it yet. Keeping it separate means a reviewer can check the API surface without reading concurrency logic.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to the inline `mod tests` in `src/item/rdbc/unified_writer_builder.rs`:
+
+```rust
+#[test]
+fn should_default_concurrency_to_one() {
+    let writer = RdbcItemWriterBuilder::<TestItem>::new()
+        .table("items")
+        .column("id", |i: &TestItem| ColumnValue::Int(i.id as i64))
+        .build_postgres();
+
+    assert_eq!(
+        writer.concurrency, 1,
+        "default must be sequential so nobody opts in by accident"
+    );
+}
+
+#[test]
+fn should_carry_configured_concurrency_to_the_writer() {
+    let writer = RdbcItemWriterBuilder::<TestItem>::new()
+        .table("items")
+        .column("id", |i: &TestItem| ColumnValue::Int(i.id as i64))
+        .with_concurrency(4)
+        .build_postgres();
+
+    assert_eq!(writer.concurrency, 4);
+}
+
+#[test]
+fn should_force_sqlite_to_stay_sequential() {
+    let writer = RdbcItemWriterBuilder::<TestItem>::new()
+        .table("items")
+        .column("id", |i: &TestItem| ColumnValue::Int(i.id as i64))
+        .with_concurrency(8)
+        .build_sqlite();
+
+    // SqliteItemWriter has no concurrency field at all — this test asserts the
+    // builder compiles and yields a working writer, i.e. the setting is
+    // accepted and ignored rather than rejected.
+    assert!(writer.table.is_some());
+}
+```
+
+`TestItem` already exists in that test module (see the struct near `unified_writer_builder.rs:364`); reuse it rather than defining another.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features --lib item::rdbc::unified_writer_builder`
+Expected: FAIL to compile — no `with_concurrency`, no `concurrency` field.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `unified_writer_builder.rs`, add the field to the struct (after `column_bindings`, :104):
+
+```rust
+    concurrency: usize,
+```
+
+Initialise it in `new()` (:109):
+
+```rust
+            concurrency: 1,
+```
+
+Add the setter next to `table` (:197):
+
+```rust
+    /// Sets how many chunk writes may be in flight at once.
+    ///
+    /// Defaults to `1`, which keeps the sequential behaviour: each `write` call
+    /// completes its INSERT before returning. Values above `1` dispatch writes
+    /// concurrently over the connection pool, which changes two observable things:
+    ///
+    /// - Chunks are no longer written in order.
+    /// - A write error surfaces on a later `write` call, or at `close`, rather than
+    ///   the call that dispatched it. `skip_limit` therefore applies with a delay of
+    ///   up to `concurrency` chunks.
+    ///
+    /// Only PostgreSQL and MySQL honour this. SQLite serialises writes behind a
+    /// database-level lock, so `build_sqlite` ignores the setting.
+    ///
+    /// Keep this at or below the connection pool size; extra tasks would only queue
+    /// waiting for a connection.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use spring_batch_rs::item::rdbc::ColumnValue;
+    ///
+    /// struct Order { id: i32 }
+    ///
+    /// let builder = RdbcItemWriterBuilder::<Order>::new()
+    ///     .table("orders")
+    ///     .column("id", |o: &Order| ColumnValue::Int(o.id as i64))
+    ///     .with_concurrency(4);
+    ///
+    /// let writer = builder.build_postgres();
+    /// assert_eq!(writer.concurrency, 4);
+    /// ```
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+```
+
+In `build_postgres` (:252) and `build_mysql` (:291), pass `concurrency: self.concurrency` into the constructed writer. In `build_sqlite` (:330), warn and ignore:
+
+```rust
+        if self.concurrency > 1 {
+            log::warn!(
+                "with_concurrency({}) ignored for SQLite: writes are serialised by a \
+                 database-level lock, so concurrency would add no throughput",
+                self.concurrency
+            );
+        }
+```
+
+In `postgres_writer.rs`, add `pub(crate) concurrency: usize` to the struct (:43-48) and `concurrency: 1` to `new()` (:52-57). Do the same in `mysql_writer.rs`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib item::rdbc && cargo test --doc --all-features unified_writer_builder`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/rdbc/unified_writer_builder.rs src/item/rdbc/postgres_writer.rs src/item/rdbc/mysql_writer.rs
+git commit -m "feat: add with_concurrency to RdbcItemWriterBuilder
+
+Carries the setting to the Postgres and MySQL writers; nothing consumes
+it yet. SQLite warns and ignores it."
+```
+
+---
+
+### Task 4: Concurrent path in the PostgreSQL writer
+
+**Files:**
+- Modify: `src/item/rdbc/postgres_writer.rs` — the `write` body (around :95-135) and the `ItemWriter` impl to add `close`
+- Test: inline `mod tests` in the same file
+
+**Interfaces:**
+- Consumes: `InflightWrites::{new, spawn, harvest, drain}` (Task 2), `writer.concurrency` (Task 3), the fatal `close()` behaviour (Task 1).
+- Produces: `PostgresItemWriter` honouring `concurrency`, with `flush` harvesting and `close` draining. Task 5 mirrors this shape for MySQL.
+
+- [ ] **Step 1: Write the failing tests**
+
+The existing tests in this file are builder-state tests that need no database. Add these, which also need none:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_take_the_sequential_path_when_concurrency_is_one() {
+    let writer = PostgresItemWriter::<String>::new();
+
+    // No pool configured: the sequential path must fail validation immediately
+    // rather than dispatching anything.
+    let result = writer.write(&["a".to_string()]);
+
+    assert!(result.is_err(), "no pool means validate_config must reject");
+    assert_eq!(writer.concurrency, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_report_no_error_from_flush_and_close_when_idle() {
+    let writer = PostgresItemWriter::<String>::new();
+
+    assert!(ItemWriter::<String>::flush(&writer).is_ok());
+    assert!(ItemWriter::<String>::close(&writer).is_ok());
+}
+```
+
+The real proof that writes overlap lives in `InflightWrites`' own tests (Task 2) and in the benchmark (Task 6). Do not attempt to fake a `sqlx::Pool` here.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features --lib item::rdbc::postgres_writer`
+Expected: FAIL to compile — `PostgresItemWriter` has no `close` in its `ItemWriter` impl and no `inflight` field.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add to the struct in `postgres_writer.rs`:
+
+```rust
+    pub(crate) inflight: std::cell::RefCell<Option<InflightWrites>>,
+```
+
+and `inflight: std::cell::RefCell::new(None)` to `new()`. Import `use crate::item::rdbc::inflight_writes::InflightWrites;`.
+
+The `Option` is lazy initialisation: the table name is not known until `write` runs.
+
+Restructure `write` so the sequential path is untouched:
+
+```rust
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        if self.concurrency <= 1 {
+            return self.write_sequential(pool, table, items);
+        }
+
+        self.write_concurrent(pool, table, items)
+    }
+```
+
+Move the current body verbatim into `write_sequential(&self, pool: &sqlx::Pool<Postgres>, table: &str, items: &[O]) -> ItemWriterResult` — do not alter it while moving.
+
+Add the concurrent path:
+
+```rust
+    /// Dispatches the chunk as a task, bounded by `concurrency`.
+    ///
+    /// Column values are extracted here, on the calling thread, because the
+    /// extractor closures are not `Send`. Only the resulting `ColumnValue`s —
+    /// which are `Send + 'static` — cross into the spawned task.
+    fn write_concurrent(
+        &self,
+        pool: &sqlx::Pool<Postgres>,
+        table: &str,
+        items: &[O],
+    ) -> ItemWriterResult {
+        let rows: Vec<Vec<ColumnValue>> = items
+            .iter()
+            .map(|item| {
+                self.column_bindings
+                    .iter()
+                    .map(|(_, extractor)| extractor(item))
+                    .collect()
+            })
+            .collect();
+
+        let col_list = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let pool = pool.clone();
+        let table_owned = table.to_string();
+
+        let mut guard = self.inflight.borrow_mut();
+        let inflight = guard.get_or_insert_with(|| {
+            InflightWrites::new(self.concurrency, table.to_string(), "PostgreSQL")
+        });
+
+        inflight.spawn(async move {
+            let mut query_builder = QueryBuilder::new("INSERT INTO ");
+            query_builder.push(&table_owned);
+            query_builder.push(" (");
+            query_builder.push(&col_list);
+            query_builder.push(") ");
+            // `into_iter` rather than `iter`: bind_column_value! moves the value
+            // out of the enum (writer_common.rs:96), so consuming the rows avoids
+            // a clone per column on the hot path.
+            query_builder.push_values(rows.into_iter(), |mut b, row| {
+                for value in row {
+                    bind_column_value!(b, value);
+                }
+            });
+            query_builder.build().execute(&pool).await.map(|_| ())
+        })
+    }
+```
+
+Then add `flush` and `close` to the `ItemWriter` impl:
+
+```rust
+    /// Collects results of finished writes without waiting.
+    ///
+    /// Deliberately non-blocking: the step engine calls this after every chunk,
+    /// so waiting here would serialise the concurrent path back into sequence.
+    fn flush(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.harvest(),
+            None => Ok(()),
+        }
+    }
+
+    /// Waits for every in-flight write and reports the first failure.
+    fn close(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.drain(),
+            None => Ok(()),
+        }
+    }
+```
+
+If `bind_column_value!` cannot accept an owned `ColumnValue`, read its definition in
+`src/item/rdbc/` and adapt the call rather than changing the macro — other writers depend on it.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib item::rdbc && cargo clippy --all-features --lib -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/rdbc/postgres_writer.rs
+git commit -m "feat: concurrent chunk writes in the PostgreSQL writer"
+```
+
+---
+
+### Task 5: Concurrent path in the MySQL writer
+
+**Files:**
+- Modify: `src/item/rdbc/mysql_writer.rs` — the `write` body (around :100-140) and the `ItemWriter` impl
+- Test: inline `mod tests` in the same file
+
+**Interfaces:**
+- Consumes: `InflightWrites` (Task 2), `writer.concurrency` (Task 3).
+- Produces: nothing later tasks depend on.
+
+Apply the same shape as Task 4, with `MySql` in place of `Postgres` and `"MySQL"` as the `db_name` passed to `InflightWrites::new`. Read Task 4's implementation before starting — the structure is deliberately identical, and divergence between the two writers is a defect, not a style choice.
+
+- [ ] **Step 1: Write the failing tests**
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_take_the_sequential_path_when_concurrency_is_one() {
+    let writer = MySqlItemWriter::<String>::new();
+
+    let result = writer.write(&["a".to_string()]);
+
+    assert!(result.is_err(), "no pool means validate_config must reject");
+    assert_eq!(writer.concurrency, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_report_no_error_from_flush_and_close_when_idle() {
+    let writer = MySqlItemWriter::<String>::new();
+
+    assert!(ItemWriter::<String>::flush(&writer).is_ok());
+    assert!(ItemWriter::<String>::close(&writer).is_ok());
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cargo test --all-features --lib item::rdbc::mysql_writer`
+Expected: FAIL to compile — no `close` impl, no `inflight` field.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Mirror Task 4 exactly:
+
+1. Add `pub(crate) inflight: std::cell::RefCell<Option<InflightWrites>>` to the struct and `RefCell::new(None)` to `new()`.
+2. Split `write` into a `concurrency <= 1` guard calling `write_sequential` (the current body, moved verbatim) and `write_concurrent`.
+3. In `write_concurrent`, extract `Vec<Vec<ColumnValue>>` on the calling thread, clone the pool, build the `QueryBuilder::<MySql>` inside the spawned future, and pass `"MySQL"` to `InflightWrites::new`.
+4. Add the same `flush` (harvest) and `close` (drain) implementations.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cargo test --all-features --lib item::rdbc && cargo clippy --all-features --lib -- -D warnings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/item/rdbc/mysql_writer.rs
+git commit -m "feat: concurrent chunk writes in the MySQL writer"
+```
+
+---
+
+### Task 6: Integration test, benchmark wiring, docs, version
+
+**Files:**
+- Modify: `tests/rdbc_postgres.rs` (add one testcontainers test)
+- Modify: `examples/benchmark_csv_postgres_xml.rs` (read a `WRITE_CONCURRENCY` env var)
+- Modify: `Cargo.toml:3` (version), `CLAUDE.md` (version line)
+- Modify: `../sbrs-docsite/src/content/docs/reference/performance.mdx`, `../sbrs-docsite/src/content/docs/item-readers-writers/overview.mdx`
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: nothing.
+
+- [ ] **Step 1: Add the integration test**
+
+In `tests/rdbc_postgres.rs`, following the existing testcontainers setup in that file:
+
+```rust
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_write_every_row_with_concurrency() {
+    // Reuse this file's existing container + pool + table setup helpers.
+    let (_container, pool) = setup_postgres().await;
+    create_test_table(&pool).await;
+
+    let items: Vec<TestRecord> = (0..10_000)
+        .map(|i| TestRecord { id: i, name: format!("row-{i}") })
+        .collect();
+
+    let reader = /* a reader over `items`, as other tests in this file do */;
+    let writer = RdbcItemWriterBuilder::<TestRecord>::new()
+        .postgres(&pool)
+        .table("test_records")
+        .column("id", |r: &TestRecord| ColumnValue::Int(r.id as i64))
+        .column("name", |r: &TestRecord| ColumnValue::Text(r.name.clone()))
+        .with_concurrency(4)
+        .build_postgres();
+
+    let step = StepBuilder::new("concurrent-write")
+        .chunk(500)
+        .reader(&reader)
+        .processor(&PassThroughProcessor::<TestRecord>::new())
+        .writer(&writer)
+        .build();
+    let job = JobBuilder::new().start(&step).build();
+    job.run().expect("job must succeed");
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM test_records")
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+
+    assert_eq!(count, 10_000, "concurrent writes must not lose or duplicate rows");
+}
+```
+
+Match the helper names actually used in `tests/rdbc_postgres.rs` — read the file first; the names above are placeholders for whatever that file already provides.
+
+- [ ] **Step 2: Run the integration test**
+
+Run: `cargo test --all-features --test rdbc_postgres should_write_every_row_with_concurrency`
+Requires Docker. If no Docker-compatible runtime is available, report that this step could not run — do not claim it passed.
+
+- [ ] **Step 3: Wire the benchmark**
+
+In `examples/benchmark_csv_postgres_xml.rs`, next to the existing `total_records()` helper:
+
+```rust
+/// Number of chunk writes allowed in flight, via `WRITE_CONCURRENCY`. Defaults to 1
+/// (sequential), matching the writer's own default.
+fn write_concurrency() -> usize {
+    env::var("WRITE_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1)
+}
+```
+
+Apply `.with_concurrency(write_concurrency())` to the two PostgreSQL writers (steps 1 and 3), and add the setting to the module doc-comment's Run section.
+
+- [ ] **Step 4: Measure**
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/benchmark" \
+  TOTAL_RECORDS=1000000 WRITE_CONCURRENCY=1 \
+  cargo run --release --example benchmark_csv_postgres_xml --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
+```
+
+Repeat with `WRITE_CONCURRENCY=2`, `4`, `8`. Record `write_duration` and total per setting in
+`docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-results.md`, one table per setting.
+
+Expect sub-linear gains: PostgreSQL's WAL and primary-key maintenance become the limit. If
+concurrency 8 is no better than 4, that is the saturation point and worth recording as the
+recommended ceiling.
+
+- [ ] **Step 5: Version and docs**
+
+`Cargo.toml:3` → `version = "0.5.0"`. Update the version line in `CLAUDE.md`.
+
+In `sbrs-docsite/src/content/docs/reference/performance.mdx`, add a section on `with_concurrency`
+covering: what it does, that it is opt-in, that ordering is not preserved, that errors are delayed
+by up to N chunks, that it should stay at or below the pool size, and the measured numbers from
+Step 4. In `item-readers-writers/overview.mdx`, note the option on the RDBC writer entry.
+**`.mdx` only — never create a `.md` sibling.**
+
+Also document the `close()` behavioural change: a failing `close()` now fails the step.
+
+- [ ] **Step 6: Verify and commit**
+
+```bash
+cargo test --all-features --lib
+cargo test --doc --all-features
+cargo clippy --all-features --lib -- -D warnings
+cargo fmt --all -- --check
+```
+
+```bash
+git add Cargo.toml CLAUDE.md examples/ tests/ docs/
+git commit -m "feat: wire concurrency into the benchmark, bump to 0.5.0"
+cd ../sbrs-docsite
+git add src/content/docs/reference/performance.mdx src/content/docs/item-readers-writers/overview.mdx
+git commit -m "docs: document with_concurrency and the close() change"
+```
+
+`sbrs-lib` and `sbrs-docsite` are separate repositories — hence two commits.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Task |
+|---|---|
+| API `with_concurrency`, default 1 | Task 3 |
+| SQLite warns and stays sequential | Task 3 |
+| Scope: PostgreSQL + MySQL only | Tasks 4, 5 |
+| Internal structure, `RefCell` | Tasks 3, 4 |
+| Non-Send closures applied on calling thread | Task 4 Step 3 (`write_concurrent`) |
+| Flow: materialise → harvest → block → spawn → report | Task 2 (`spawn`) + Task 4 |
+| `flush()` must not drain | Task 2 (`harvest` non-blocking, test) + Task 4 (`flush`) |
+| `close()` drains | Task 2 (`drain`) + Task 4 |
+| Errors delayed by ≤ N, documented | Task 3 rustdoc, Task 6 docs |
+| Ordering not preserved, documented | Task 3 rustdoc, Task 6 docs |
+| Engine: failing `close()` fails the step | Task 1 |
+| `open()` unchanged | Task 1 Step 3, explicit |
+| Testing: overlap, delayed error, final-chunk failure, sequential equivalence | Tasks 1, 2, 4, 5 |
+| Integration: 10k rows land exactly | Task 6 |
+| Measurement at 1/2/4/8 | Task 6 |
+| Semver 0.5.0 | Task 6 |
+
+No gaps.
+
+**Placeholder scan:** no TBD/TODO. Two spots defer to the codebase rather than inventing names —
+the testcontainers helpers in Task 6 Step 1 and the `bind_column_value!` shape in Task 4 — and both
+say explicitly to read the file and match what is there. That is direction, not a placeholder.
+
+**Type consistency:** `InflightWrites::{new, spawn, harvest, drain}` are defined in Task 2 and used
+under those exact names in Tasks 4 and 5. `concurrency: usize` is introduced in Task 3 and read in
+Tasks 4 and 5. `write_sequential` / `write_concurrent` are named identically in Tasks 4 and 5.
+`db_name` is `&'static str` throughout, passed as `"PostgreSQL"` and `"MySQL"` to match the strings
+the existing `create_write_error` calls already use.

--- a/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-design.md
+++ b/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-design.md
@@ -1,0 +1,182 @@
+# Concurrent RDBC Writes Design
+
+**Date:** 2026-08-03
+**Branch:** feat-concurrent-rdbc-writes
+**Status:** Approved
+
+## Summary
+
+Add opt-in concurrent chunk writing to the PostgreSQL and MySQL item writers, bounded by a
+caller-supplied degree of concurrency. Writes are dispatched to a `JoinSet` of at most N in-flight
+tokio tasks; errors are harvested on subsequent `write()` calls and drained at `close()`.
+
+Also fix an engine defect the work exposes: a failing `ItemWriter::close()` is currently swallowed
+as a warning, so a step can report success while data was never written.
+
+## Background: why this, and why not async traits
+
+The phase profiling in `2026-08-03-step-phase-profiling-design.md` measured where a step's time
+goes. At 10M rows:
+
+| Step | Total | read | process | write | flush |
+|---|---|---|---|---|---|
+| csv-to-postgres | 57.6s | 15% | 1% | **82%** | 0% |
+| postgres-to-xml | 30.8s | **78%** | 0% | 20% | 0% |
+| xml-to-postgres-import | 74.0s | 33% | 0% | **66%** | 0% |
+
+Two conclusions drove this design:
+
+- Migrating the traits to async was rejected: time is spent *waiting* on the database, and making
+  `write()` async changes who waits, not whether anyone waits.
+- Overlapping read against write caps at 26%, because each step's floor becomes its dominant
+  phase. For steps 1 and 3 that floor is PostgreSQL write time — 47.3s and 48.9s, about 210k
+  rows/s. **Cutting the dominant phase itself is the larger prize**, and that means issuing
+  several INSERTs at once.
+
+The writers currently issue one INSERT per chunk, strictly sequentially, while the pool holds 10
+connections used one at a time. With `chunk_size = 1000` and 8 columns,
+`max_items_per_batch = 65535 / 8 = 8191`, so the existing `items.chunks(max_items)` loop in
+`postgres_writer.rs:110` never splits — it is exactly one INSERT per `write()` call, 10 000 of them
+in series at ~4.7ms each.
+
+## API
+
+```rust
+let writer = RdbcItemWriterBuilder::<Transaction>::new()
+    .postgres(pool.clone())
+    .table("transactions")
+    .with_concurrency(4)      // new; default 1
+    .build_postgres();
+```
+
+Opt-in. `with_concurrency(1)`, or never calling it, takes **the existing code path unchanged** —
+not an equivalent path, the same one. Nobody inherits the reordering or the deferred error timing
+without asking for it.
+
+`build_sqlite()` with a concurrency above 1 emits a `warn!` and proceeds sequentially. SQLite
+serialises writes behind a database-level lock; an option that silently does nothing would be
+worse than no option.
+
+Scope is **PostgreSQL and MySQL only**. SeaORM and MongoDB are out of scope for this spec.
+
+## Internal structure
+
+```rust
+pub struct PostgresItemWriter<O> {
+    pool: Option<Pool<Postgres>>,
+    table: Option<String>,
+    column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+    concurrency: usize,
+    inflight: RefCell<JoinSet<Result<(), sqlx::Error>>>,
+    pending_errors: RefCell<Vec<BatchError>>,
+}
+```
+
+`RefCell` follows the pattern used throughout the crate, forced by `&self` on `ItemWriter`.
+
+### Why the non-Send closures are not a blocker
+
+`column_bindings` holds `Box<dyn Fn(&O) -> ColumnValue>` with no `Send` bound, which would
+normally prevent moving anything that touches them into a spawned task.
+
+It does not, because `ColumnValue` (`column_value.rs:21`) holds only `i64`, `f64`, `String`,
+`bool`, `Vec<u8>` and a unit variant — it is `Send + 'static`. The closures are therefore applied
+**synchronously inside `write()`**, on the calling thread, and only the resulting values cross the
+task boundary. The closures themselves never move.
+
+## Flow of `write()`
+
+With `concurrency <= 1`, dispatch straight to the current implementation and stop.
+
+Otherwise:
+
+1. **Materialise** `Vec<Vec<ColumnValue>>` by applying the bindings to each item.
+2. **Harvest** finished tasks without blocking, collecting errors into `pending_errors`.
+3. **If N tasks are in flight**, block on `join_next()` until a slot frees. This is the
+   backpressure — structural, not a counter to maintain.
+4. **Spawn** the INSERT with a cloned `Pool` (`Send + Sync + Clone`), the table name, and the
+   column list.
+5. **Return** the first pending error, if any, so the engine can count it.
+
+The materialisation in step 1 is a real cost the current code avoids: `push_values`
+(`postgres_writer.rs:117`) binds straight from the items with no intermediate buffer. It is
+accepted because `process` measures 0-1% — there is CPU headroom, and it buys against a phase at
+82%.
+
+## flush() must not drain
+
+The engine calls `flush()` after **every chunk** (`step.rs:955`). A `flush()` that waited for
+in-flight tasks would collapse the design back to sequential execution — concurrent code for no
+gain.
+
+So `flush()` harvests finished tasks only; it never waits. **`close()` is the only draining
+point.**
+
+This does not weaken any existing guarantee: the RDBC writers inherit the trait's no-op `flush()`
+today, which is exactly why `flush_duration` measured 0% at every scale.
+
+## Errors and skip_limit
+
+The engine does `write_error_count += processed_items.len()` (`step.rs:963`) — the size of the
+*current* chunk, while the error came from a chunk dispatched up to N positions earlier. Counts
+stay right in magnitude, but attribution is approximate and `skip_limit` applies with a delay
+bounded by N.
+
+This is a documented consequence of opting in, not a defect to paper over. It belongs in the
+rustdoc for `with_concurrency` and on the website's performance page.
+
+Chunk write **ordering is not preserved** under concurrency. For plain INSERTs this is harmless;
+for schemas with ordering dependencies it is not, which is another reason the feature is opt-in.
+
+## Engine fix: a failing close() must fail the step
+
+`ChunkOrientedStep::execute` calls `Self::manage_error(self.writer.close())` (`step.rs:729`), and
+`manage_error` (`step.rs:988`) only logs a warning. The error is discarded.
+
+With writes in flight, the final batch's outcome is knowable only at `close()`. Discarding it
+would let a step report `Success` while INSERTs failed — silent data loss.
+
+**Change:** a failing `close()` sets `StepStatus::WriteError` and makes the step return `Err`.
+
+This is a pre-existing defect independent of concurrency — a failing final CSV flush is swallowed
+the same way today. Fixing it is an improvement in its own right, but it is an observable
+behaviour change: a job that previously "passed" with a close error will now fail. That is the
+correct outcome, and it must be called out in the changelog.
+
+`open()` keeps its current non-fatal handling. Nothing in this design depends on changing it, and
+widening the blast radius here would serve nothing.
+
+## Non-goals
+
+- No async migration of the `ItemReader` / `ItemWriter` / `Tasklet` traits.
+- No prefetch in the readers. That is a separate, complementary change.
+- No stage pipelining in the engine.
+- No change to the per-chunk `flush()` call — measured at 0%, it stays.
+- No concurrency for SeaORM, MongoDB, or SQLite writers.
+
+## Testing
+
+Unit tests, inline per `.claude/rules/02-unit-tests.md`:
+
+- `should_overlap_writes_when_concurrency_above_one` — a writer whose INSERT sleeps; assert total
+  elapsed is nearer `total/N` than `total`.
+- `should_surface_error_from_an_earlier_chunk` — fail chunk 2 of 6, assert the error reaches the
+  engine within the following N `write()` calls.
+- `should_fail_the_step_when_the_final_chunk_fails` — fail only the last chunk, assert the step
+  ends in error. This is the test that validates the engine fix; without it the failure is
+  invisible.
+- `should_take_the_sequential_path_when_concurrency_is_one` — assert behaviour is identical to the
+  current implementation.
+- `should_warn_and_stay_sequential_on_sqlite` — assert the SQLite builder ignores the setting.
+
+Integration, with testcontainers: a concurrent write of 10k rows lands exactly 10k rows, no
+duplicates and no losses.
+
+Measurement: benchmark at 1M rows with concurrency 1, 2, 4, 8. Record throughput and
+`write_duration` per setting to find where the server saturates. The gain will not be linear in N
+— PostgreSQL's WAL and primary-key maintenance become the limit, not the client.
+
+## Semver
+
+The engine's `close()` change is a behavioural break: target **0.5.0**. `StepExecution` is already
+`#[non_exhaustive]`, so any new metric this work needs can be added without further breakage.

--- a/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-results.md
+++ b/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-results.md
@@ -2,57 +2,63 @@
 
 Measurement plan: `docs/superpowers/plans/2026-08-03-concurrent-rdbc-writes.md`, Task 6 Step 4.
 
-## Status: NOT MEASURED — blocked
+Measured 2026-08-04.
 
-The benchmark was wired (`WRITE_CONCURRENCY` env var on the two PostgreSQL write
-steps of `examples/benchmark_csv_postgres_xml.rs`) and compiles in release mode,
-but the measurement itself has not been run.
+## Setup
 
-Blocker, as of 2026-08-04:
-
-- No Docker-compatible runtime available on this machine
-  (`unix:///Users/sboussekeyt/.docker/run/docker.sock` — daemon not running).
-- No PostgreSQL listening on `127.0.0.1:5432` either.
-
-The same blocker prevented running the testcontainers integration test
-`should_write_every_row_with_concurrency` in `tests/rdbc_postgres.rs`. That test
-compiles but has never executed, so **the end-to-end claim that 10 000 rows land
-exactly once under concurrency is unverified**.
-
-## How to run it once a database is available
-
-```bash
-docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres \
-  -e POSTGRES_DB=benchmark postgres:15
-```
-
-Then, for each of `WRITE_CONCURRENCY=1`, `2`, `4`, `8`:
+- 1 000 000 rows, chunk = 1 000, 8 columns.
+- PostgreSQL 15 in Apple `container` (4 vCPU, 1 GB), port published on `127.0.0.1:5432`.
+- Connection pool: `max_connections(10)` — every setting below stays under that ceiling.
+- `.with_concurrency()` applies to steps 1 and 3 only (the two PostgreSQL writers).
+  Step 2 writes XML and is unaffected; it serves as a control.
 
 ```bash
 DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/benchmark" \
-  TOTAL_RECORDS=1000000 WRITE_CONCURRENCY=1 \
+  TOTAL_RECORDS=1000000 WRITE_CONCURRENCY=<N> \
   cargo run --release --example benchmark_csv_postgres_xml \
   --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
 ```
 
-And the integration test:
+## Results
 
-```bash
-cargo test --all-features --test rdbc_postgres should_write_every_row_with_concurrency
-```
+| WRITE_CONCURRENCY | step 1 write | step 3 write | step 1 total | step 3 total | wall-clock | throughput |
+|---|---|---|---|---|---|---|
+| 1 | 4.7 s | 5.0 s | 5.8 s | 7.4 s | 16.7 s | 59 934 rec/s |
+| 2 | 1.2 s | 0.3 s | 2.0 s | 2.2 s | 7.3 s | 136 460 rec/s |
+| 4 | 0.8 s | 0.1 s | 1.2 s | 2.0 s | 6.5 s | 154 776 rec/s |
+| 8 | 0.7 s | 0.1 s | 1.1 s | 2.0 s | 6.2 s | 160 075 rec/s |
 
-## Table to fill in
+Control: step 2 (`postgres-to-xml`, no concurrency applied) stayed at 3.0–3.5 s across
+all four settings, as expected.
 
-One row per setting, taking `write_duration` from the step phase summary.
+**Cold-cache check.** `WRITE_CONCURRENCY=1` ran first, so it was re-run last, with the
+cache warm: 17.2 s (vs 16.7 s). The sequential baseline is genuinely the slowest — the
+gain is not a warm-up artefact.
 
-| WRITE_CONCURRENCY | step 1 write_duration | step 3 write_duration | total wall-clock |
-|---|---|---|---|
-| 1 | | | |
-| 2 | | | |
-| 4 | | | |
-| 8 | | | |
+**Row-count check.** After the `WRITE_CONCURRENCY=8` pass, both tables held exactly
+1 000 000 rows. Concurrent writes lost and duplicated nothing at 1M rows, 1 000 chunks
+deep.
 
-Expect sub-linear gains: PostgreSQL's WAL and primary-key maintenance become the
-limit. If 8 is no better than 4, that is the saturation point and should be
-recorded as the recommended ceiling in
-`sbrs-docsite/src/content/docs/reference/performance.mdx`.
+## Reading of the numbers
+
+- **The write phase collapses.** Step 1's write goes 4.7 s → 0.7 s (6.7×), step 3's
+  5.0 s → 0.1 s (50×). This confirms the diagnosis from the phase-profiling study: the
+  sequential writer left a 10-connection pool being used one connection at a time.
+- **Gains are strongly sub-linear, and saturate at 4.** 1 → 2 halves the wall-clock;
+  2 → 4 buys 0.8 s; 4 → 8 buys 0.3 s. Past 4, PostgreSQL's WAL and index maintenance
+  are the limit, not the client.
+- **Recommended ceiling: 4.** 8 is measurably but marginally faster (5 %) while doubling
+  the delay on error reporting and the number of unordered in-flight chunks. Not worth it.
+- **The bottleneck moves, it does not vanish.** At concurrency ≥ 2 both write steps
+  become read-bound (step 3's read share goes 32 % → 92 %), and step 2 — untouched by
+  this feature — becomes the single largest step. Further work belongs on the read side.
+
+End-to-end: 16.7 s → 6.2 s, i.e. **2.7× on the full 3-step pipeline** for a 1-line
+opt-in change.
+
+## Still not verified
+
+`tests/rdbc_postgres.rs::should_write_every_row_with_concurrency` compiles but has
+never run: it uses testcontainers, which requires a Docker Engine API socket, and this
+machine runs Apple `container` instead. The row-count check above covers the same claim
+empirically, at 100× the scale, but the test itself remains unexecuted.

--- a/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-results.md
+++ b/docs/superpowers/specs/2026-08-03-concurrent-rdbc-writes-results.md
@@ -1,0 +1,58 @@
+# Concurrent RDBC Writes — Measurement Results
+
+Measurement plan: `docs/superpowers/plans/2026-08-03-concurrent-rdbc-writes.md`, Task 6 Step 4.
+
+## Status: NOT MEASURED — blocked
+
+The benchmark was wired (`WRITE_CONCURRENCY` env var on the two PostgreSQL write
+steps of `examples/benchmark_csv_postgres_xml.rs`) and compiles in release mode,
+but the measurement itself has not been run.
+
+Blocker, as of 2026-08-04:
+
+- No Docker-compatible runtime available on this machine
+  (`unix:///Users/sboussekeyt/.docker/run/docker.sock` — daemon not running).
+- No PostgreSQL listening on `127.0.0.1:5432` either.
+
+The same blocker prevented running the testcontainers integration test
+`should_write_every_row_with_concurrency` in `tests/rdbc_postgres.rs`. That test
+compiles but has never executed, so **the end-to-end claim that 10 000 rows land
+exactly once under concurrency is unverified**.
+
+## How to run it once a database is available
+
+```bash
+docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=benchmark postgres:15
+```
+
+Then, for each of `WRITE_CONCURRENCY=1`, `2`, `4`, `8`:
+
+```bash
+DATABASE_URL="postgresql://postgres:postgres@127.0.0.1:5432/benchmark" \
+  TOTAL_RECORDS=1000000 WRITE_CONCURRENCY=1 \
+  cargo run --release --example benchmark_csv_postgres_xml \
+  --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
+```
+
+And the integration test:
+
+```bash
+cargo test --all-features --test rdbc_postgres should_write_every_row_with_concurrency
+```
+
+## Table to fill in
+
+One row per setting, taking `write_duration` from the step phase summary.
+
+| WRITE_CONCURRENCY | step 1 write_duration | step 3 write_duration | total wall-clock |
+|---|---|---|---|
+| 1 | | | |
+| 2 | | | |
+| 4 | | | |
+| 8 | | | |
+
+Expect sub-linear gains: PostgreSQL's WAL and primary-key maintenance become the
+limit. If 8 is no better than 4, that is the saturation point and should be
+recorded as the recommended ceiling in
+`sbrs-docsite/src/content/docs/reference/performance.mdx`.

--- a/examples/benchmark_csv_postgres_xml.rs
+++ b/examples/benchmark_csv_postgres_xml.rs
@@ -31,6 +31,16 @@
 //!   --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
 //! ```
 //!
+//! Set WRITE_CONCURRENCY to allow several chunk INSERTs in flight at once on the two
+//! PostgreSQL write steps (defaults to 1, i.e. sequential). Keep it at or below the
+//! connection pool size:
+//!
+//! ```bash
+//! TOTAL_RECORDS=1000000 WRITE_CONCURRENCY=4 \
+//!   cargo run --release --example benchmark_csv_postgres_xml \
+//!   --features csv,xml,rdbc-postgres 2>&1 | grep "Step '"
+//! ```
+//!
 //! Each step prints its per-phase timing breakdown (read / process / write / flush)
 //! on stderr via `StepExecution::phase_summary()`.
 
@@ -133,6 +143,15 @@ fn total_records() -> u64 {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(DEFAULT_TOTAL_RECORDS)
+}
+
+/// Number of chunk writes allowed in flight, via `WRITE_CONCURRENCY`. Defaults to 1
+/// (sequential), matching the writer's own default.
+fn write_concurrency() -> usize {
+    env::var("WRITE_CONCURRENCY")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1)
 }
 
 /// Generates a CSV file with `count` random financial transaction rows.
@@ -434,6 +453,7 @@ async fn main() -> Result<(), BatchError> {
         .column("account_to", |t: &Transaction| t.account_to.clone().into())
         .column("status", |t: &Transaction| t.status.clone().into())
         .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+        .with_concurrency(write_concurrency())
         .build_postgres();
     let processor1 = TransactionProcessor;
     let step1 = StepBuilder::new("csv-to-postgres")
@@ -489,6 +509,7 @@ async fn main() -> Result<(), BatchError> {
         .column("account_to", |t: &Transaction| t.account_to.clone().into())
         .column("status", |t: &Transaction| t.status.clone().into())
         .column("amount_eur", |t: &Transaction| t.amount_eur.into())
+        .with_concurrency(write_concurrency())
         .build_postgres();
     let processor3 = PassThroughProcessor::<Transaction>::new();
     let step3 = StepBuilder::new("xml-to-postgres-import")

--- a/src/core/step.rs
+++ b/src/core/step.rs
@@ -725,8 +725,13 @@ impl<I, O> Step for ChunkOrientedStep<'_, I, O> {
             }
         }
 
-        // Close the writer and handle any errors
-        Self::manage_error(self.writer.close());
+        // A failing close() means buffered or in-flight writes never landed.
+        // Treat it as fatal: reporting Success here would hide data loss.
+        let close_result = self.writer.close();
+        if let Err(ref error) = close_result {
+            warn!("Error closing writer: {}", error);
+            step_execution.status = StepStatus::WriteError;
+        }
 
         // Log the end of the step
         info!(
@@ -2320,9 +2325,10 @@ mod tests {
 
         let result = step.execute(&mut step_execution);
 
-        // The step should still succeed as close errors are managed
-        assert!(result.is_ok());
-        assert_eq!(step_execution.status, StepStatus::Success);
+        // A failing close() means writes never landed. Reporting Success here
+        // would hide data loss, so the step must fail.
+        assert!(result.is_err());
+        assert_eq!(step_execution.status, StepStatus::WriteError);
 
         Ok(())
     }
@@ -3288,11 +3294,44 @@ mod tests {
 
         let result = step.execute(&mut step_execution);
 
-        // Should still succeed as open/close errors are managed
-        assert!(result.is_ok());
-        assert_eq!(step_execution.status, StepStatus::Success);
+        // open() failing stays non-fatal; close() failing is what fails the step.
+        assert!(result.is_err());
+        assert_eq!(step_execution.status, StepStatus::WriteError);
 
         Ok(())
+    }
+
+    #[test]
+    fn should_not_fail_the_step_when_only_open_fails() {
+        let mut reader = MockTestItemReader::default();
+        reader.expect_read().return_once(|| Ok(None));
+
+        let mut processor = MockTestProcessor::default();
+        processor.expect_process().never();
+
+        let mut writer = MockTestItemWriter::default();
+        writer
+            .expect_open()
+            .times(1)
+            .returning(|| Err(BatchError::ItemWriter("open error".to_string())));
+        writer.expect_write().never();
+        writer.expect_close().times(1).returning(|| Ok(()));
+
+        let step = StepBuilder::new("open-fails-only")
+            .chunk(3)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new(&step.name);
+        let result = step.execute(&mut step_execution);
+
+        assert!(
+            result.is_ok(),
+            "a failing open() must stay non-fatal; only close() became fatal"
+        );
+        assert_eq!(step_execution.status, StepStatus::Success);
     }
 
     #[test]
@@ -3667,5 +3706,78 @@ mod tests {
             "the empty-chunk early return skips the writer entirely"
         );
         assert_eq!(step_execution.flush_duration, Duration::ZERO);
+    }
+
+    #[test]
+    fn should_fail_the_step_when_close_fails() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            counter += 1;
+            if counter > 2 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| Ok(()));
+        writer.expect_flush().returning(|| Ok(()));
+        writer
+            .expect_close()
+            .returning(|| Err(BatchError::ItemWriter("close failed".to_string())));
+
+        let step = StepBuilder::new("close-fails")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("close-fails");
+        let result = step.execute(&mut step_execution);
+
+        assert!(
+            result.is_err(),
+            "a failing close() must fail the step, otherwise unwritten data is reported as success"
+        );
+        assert_eq!(step_execution.status, StepStatus::WriteError);
+    }
+
+    #[test]
+    fn should_still_succeed_when_close_succeeds() {
+        let mut reader = MockTestItemReader::default();
+        let mut counter = 0u16;
+        reader.expect_read().returning(move || {
+            counter += 1;
+            if counter > 2 {
+                Ok(None)
+            } else {
+                Ok(sample_car())
+            }
+        });
+
+        let processor = PassThroughProcessor::<Car>::new();
+
+        let mut writer = MockTestItemWriter::default();
+        writer.expect_open().returning(|| Ok(()));
+        writer.expect_write().returning(|_| Ok(()));
+        writer.expect_flush().returning(|| Ok(()));
+        writer.expect_close().returning(|| Ok(()));
+
+        let step = StepBuilder::new("close-ok")
+            .chunk(10)
+            .reader(&reader)
+            .processor(&processor)
+            .writer(&writer)
+            .build();
+
+        let mut step_execution = StepExecution::new("close-ok");
+        assert!(step.execute(&mut step_execution).is_ok());
+        assert_eq!(step_execution.status, StepStatus::Success);
     }
 }

--- a/src/item/rdbc/inflight_writes.rs
+++ b/src/item/rdbc/inflight_writes.rs
@@ -1,0 +1,234 @@
+//! Bounded concurrency for chunk writes.
+//!
+//! Holds at most `limit` in-flight write tasks. Errors are surfaced when
+//! harvested — on a later call, or at [`InflightWrites::drain`] — never at the
+//! moment the failing write was dispatched.
+
+use std::future::Future;
+
+use tokio::task::JoinSet;
+
+use crate::BatchError;
+use crate::item::rdbc::writer_common::create_write_error;
+
+/// A bounded set of in-flight database writes.
+///
+/// # Implementation Note
+///
+/// `spawn` blocks when the limit is reached; that block *is* the backpressure,
+/// so no separate counter is maintained. `harvest` never blocks, because the
+/// step engine calls `ItemWriter::flush` after every chunk and blocking there
+/// would serialise everything again.
+pub(crate) struct InflightWrites {
+    limit: usize,
+    set: JoinSet<Result<(), sqlx::Error>>,
+    table: String,
+    db_name: &'static str,
+}
+
+impl InflightWrites {
+    /// Creates a set allowing at most `limit` concurrent writes.
+    ///
+    /// A `limit` of zero is clamped to one: a zero limit would make [`spawn`]
+    /// loop forever waiting for a slot it can never get.
+    ///
+    /// [`spawn`]: InflightWrites::spawn
+    pub(crate) fn new(limit: usize, table: String, db_name: &'static str) -> Self {
+        Self {
+            limit: limit.max(1),
+            set: JoinSet::new(),
+            table,
+            db_name,
+        }
+    }
+
+    /// Dispatches a write, first waiting for a slot if the limit is reached.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`] if a *previously* dispatched write
+    /// failed and was harvested while making room.
+    pub(crate) fn spawn<F>(&mut self, fut: F) -> Result<(), BatchError>
+    where
+        F: Future<Output = Result<(), sqlx::Error>> + Send + 'static,
+    {
+        let mut first_error = self.harvest();
+
+        while self.set.len() >= self.limit {
+            let joined = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(self.set.join_next())
+            });
+            match joined {
+                Some(outcome) => {
+                    if let Err(e) = self.interpret(outcome)
+                        && first_error.is_ok()
+                    {
+                        first_error = Err(e);
+                    }
+                }
+                None => break,
+            }
+        }
+
+        self.set.spawn(fut);
+        first_error
+    }
+
+    /// Collects results of already-finished writes without waiting.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`] for the first failed write collected.
+    pub(crate) fn harvest(&mut self) -> Result<(), BatchError> {
+        let mut first_error = Ok(());
+        while let Some(outcome) = self.set.try_join_next() {
+            if let Err(e) = self.interpret(outcome)
+                && first_error.is_ok()
+            {
+                first_error = Err(e);
+            }
+        }
+        first_error
+    }
+
+    /// Waits for every in-flight write and returns the first error found.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`] for the first failed write.
+    pub(crate) fn drain(&mut self) -> Result<(), BatchError> {
+        let mut first_error = Ok(());
+        loop {
+            let joined = tokio::task::block_in_place(|| {
+                tokio::runtime::Handle::current().block_on(self.set.join_next())
+            });
+            match joined {
+                Some(outcome) => {
+                    if let Err(e) = self.interpret(outcome)
+                        && first_error.is_ok()
+                    {
+                        first_error = Err(e);
+                    }
+                }
+                None => break,
+            }
+        }
+        first_error
+    }
+
+    /// Turns a join outcome into a batch-level result.
+    fn interpret(
+        &self,
+        outcome: Result<Result<(), sqlx::Error>, tokio::task::JoinError>,
+    ) -> Result<(), BatchError> {
+        match outcome {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(e)) => Err(create_write_error(&self.table, self.db_name, e)),
+            Err(join_error) => Err(create_write_error(&self.table, self.db_name, join_error)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, Instant};
+
+    fn ok_after(
+        ms: u64,
+    ) -> impl std::future::Future<Output = Result<(), sqlx::Error>> + Send + 'static {
+        async move {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            Ok(())
+        }
+    }
+
+    fn fail_after(
+        ms: u64,
+    ) -> impl std::future::Future<Output = Result<(), sqlx::Error>> + Send + 'static {
+        async move {
+            tokio::time::sleep(Duration::from_millis(ms)).await;
+            Err(sqlx::Error::PoolClosed)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_overlap_writes_up_to_the_limit() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+
+        let start = Instant::now();
+        for _ in 0..4 {
+            inflight.spawn(ok_after(100)).unwrap();
+        }
+        inflight.drain().unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_millis(300),
+            "4 x 100ms writes with limit 4 should overlap, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_block_when_the_limit_is_reached() {
+        let mut inflight = InflightWrites::new(2, "t".to_string(), "TestDb");
+
+        let start = Instant::now();
+        for _ in 0..4 {
+            inflight.spawn(ok_after(100)).unwrap();
+        }
+        inflight.drain().unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed >= Duration::from_millis(200),
+            "4 x 100ms writes with limit 2 must serialise into 2 waves, took {:?}",
+            elapsed
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_surface_error_on_drain() {
+        let mut inflight = InflightWrites::new(4, "orders".to_string(), "TestDb");
+
+        inflight.spawn(ok_after(10)).unwrap();
+        inflight.spawn(fail_after(10)).unwrap();
+
+        let result = inflight.drain();
+
+        assert!(result.is_err(), "drain must surface a failed write");
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("TestDb"),
+            "error should name the database, got: {message}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_report_no_error_when_nothing_was_spawned() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+
+        assert!(inflight.harvest().is_ok());
+        assert!(inflight.drain().is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_not_block_on_harvest() {
+        let mut inflight = InflightWrites::new(4, "t".to_string(), "TestDb");
+        inflight.spawn(ok_after(500)).unwrap();
+
+        let start = Instant::now();
+        let result = inflight.harvest();
+        let elapsed = start.elapsed();
+
+        assert!(result.is_ok());
+        assert!(
+            elapsed < Duration::from_millis(50),
+            "harvest must not wait for in-flight tasks, took {:?}",
+            elapsed
+        );
+
+        inflight.drain().unwrap();
+    }
+}

--- a/src/item/rdbc/mod.rs
+++ b/src/item/rdbc/mod.rs
@@ -7,6 +7,9 @@ mod select_builder;
 /// Common utilities for database item writers.
 mod writer_common;
 
+/// Bounded concurrency for in-flight chunk writes.
+mod inflight_writes;
+
 /// Common utilities for database item readers.
 mod reader_common;
 

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -46,6 +46,7 @@ pub struct MySqlItemWriter<O> {
     pub(crate) table: Option<String>,
     #[allow(clippy::type_complexity)]
     pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+    pub(crate) concurrency: usize,
 }
 
 impl<O> MySqlItemWriter<O> {
@@ -55,7 +56,35 @@ impl<O> MySqlItemWriter<O> {
             pool: None,
             table: None,
             column_bindings: Vec::new(),
+            concurrency: 1,
         }
+    }
+
+    /// Returns how many chunk writes this writer may keep in flight at once.
+    ///
+    /// `1` — the default — means writes are sequential. See
+    /// [`RdbcItemWriterBuilder::with_concurrency`](crate::item::rdbc::RdbcItemWriterBuilder::with_concurrency).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    ///
+    /// let writer = RdbcItemWriterBuilder::<String>::new()
+    ///     .table("t")
+    ///     .column("v", |s: &String| s.as_str().into())
+    ///     .build_mysql();
+    ///
+    /// assert_eq!(writer.concurrency(), 1, "writes are sequential unless opted in");
+    /// ```
+    pub fn concurrency(&self) -> usize {
+        self.concurrency
+    }
+
+    /// Sets how many chunk writes may be in flight at once.
+    pub(crate) fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
     }
 
     /// Sets the database connection pool for the writer.

--- a/src/item/rdbc/mysql_writer.rs
+++ b/src/item/rdbc/mysql_writer.rs
@@ -1,8 +1,11 @@
+use std::cell::RefCell;
+
 use serde::Serialize;
 use sqlx::{MySql, Pool, QueryBuilder};
 
 use crate::core::item::{ItemWriter, ItemWriterResult};
 use crate::item::rdbc::ColumnValue;
+use crate::item::rdbc::inflight_writes::InflightWrites;
 
 use super::writer_common::{
     bind_column_value, create_write_error, log_write_success, max_items_per_batch, validate_config,
@@ -47,6 +50,11 @@ pub struct MySqlItemWriter<O> {
     #[allow(clippy::type_complexity)]
     pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
     pub(crate) concurrency: usize,
+    /// In-flight writes, created on first concurrent write.
+    ///
+    /// The `Option` is lazy initialisation: the table name is not known until
+    /// `write` runs. Stays `None` for the sequential path.
+    pub(crate) inflight: RefCell<Option<InflightWrites>>,
 }
 
 impl<O> MySqlItemWriter<O> {
@@ -57,6 +65,7 @@ impl<O> MySqlItemWriter<O> {
             table: None,
             column_bindings: Vec::new(),
             concurrency: 1,
+            inflight: RefCell::new(None),
         }
     }
 
@@ -116,18 +125,11 @@ impl<O> Default for MySqlItemWriter<O> {
     }
 }
 
-impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
-    fn write(&self, items: &[O]) -> ItemWriterResult {
-        if items.is_empty() {
-            return Ok(());
-        }
-
-        let (pool, table) = validate_config(
-            self.pool.as_ref(),
-            self.table.as_deref(),
-            self.column_bindings.len(),
-        )?;
-
+impl<O> MySqlItemWriter<O> {
+    /// Writes the chunk with one blocking INSERT per bind-limited batch.
+    ///
+    /// This is the default path, taken whenever `concurrency <= 1`.
+    fn write_sequential(&self, pool: &Pool<MySql>, table: &str, items: &[O]) -> ItemWriterResult {
         let col_names: Vec<&str> = self
             .column_bindings
             .iter()
@@ -162,6 +164,115 @@ impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
 
         log_write_success(items.len(), table, "MySQL");
         Ok(())
+    }
+
+    /// Dispatches the chunk as a task, bounded by `concurrency`.
+    ///
+    /// Column values are extracted here, on the calling thread, because the
+    /// extractor closures are not `Send`. Only the resulting `ColumnValue`s —
+    /// which are `Send + 'static` — cross into the spawned task.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`](crate::BatchError::ItemWriter) if an
+    /// *earlier* write failed and was harvested while making room for this one.
+    fn write_concurrent(&self, pool: &Pool<MySql>, table: &str, items: &[O]) -> ItemWriterResult {
+        let col_list = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        // Same bind-limit split as the sequential path: a chunk larger than the
+        // limit must become several INSERTs on both paths, or a chunk size that
+        // works sequentially would fail once concurrency is enabled.
+        let max_items = max_items_per_batch(self.column_bindings.len());
+
+        let mut guard = self.inflight.borrow_mut();
+        let inflight = guard.get_or_insert_with(|| {
+            InflightWrites::new(self.concurrency, table.to_string(), "MySQL")
+        });
+
+        let mut first_error = Ok(());
+        for chunk in items.chunks(max_items) {
+            let batch: Vec<Vec<ColumnValue>> = chunk
+                .iter()
+                .map(|item| {
+                    self.column_bindings
+                        .iter()
+                        .map(|(_, extractor)| extractor(item))
+                        .collect()
+                })
+                .collect();
+
+            let pool = pool.clone();
+            let table_owned = table.to_string();
+            let col_list = col_list.clone();
+
+            let dispatched = inflight.spawn(async move {
+                let mut query_builder = QueryBuilder::new("INSERT INTO ");
+                query_builder.push(&table_owned);
+                query_builder.push(" (");
+                query_builder.push(&col_list);
+                query_builder.push(") ");
+                // `into_iter` rather than `iter`: bind_column_value! moves the value
+                // out of the enum, so consuming the rows avoids a clone per column
+                // on the hot path.
+                query_builder.push_values(batch, |mut b, row| {
+                    for value in row {
+                        bind_column_value!(b, value);
+                    }
+                });
+                query_builder.build().execute(&pool).await.map(|_| ())
+            });
+
+            if dispatched.is_err() && first_error.is_ok() {
+                first_error = dispatched;
+            }
+        }
+
+        first_error
+    }
+}
+
+impl<O: Serialize + Clone> ItemWriter<O> for MySqlItemWriter<O> {
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        if self.concurrency <= 1 {
+            return self.write_sequential(pool, table, items);
+        }
+
+        self.write_concurrent(pool, table, items)
+    }
+
+    /// Collects results of finished writes without waiting.
+    ///
+    /// Deliberately non-blocking: the step engine calls this after every chunk,
+    /// so waiting here would serialise the concurrent path back into sequence.
+    /// Always `Ok` on the sequential path, which keeps nothing in flight.
+    fn flush(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.harvest(),
+            None => Ok(()),
+        }
+    }
+
+    /// Waits for every in-flight write and reports the first failure.
+    fn close(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.drain(),
+            None => Ok(()),
+        }
     }
 }
 
@@ -219,5 +330,90 @@ mod tests {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
+    }
+
+    // --- concurrency ---
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_take_the_sequential_path_when_concurrency_is_one() {
+        let writer = MySqlItemWriter::<String>::new();
+
+        let result = writer.write(&["a".to_string()]);
+
+        assert!(result.is_err(), "no pool means validate_config must reject");
+        assert_eq!(writer.concurrency, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_report_no_error_from_flush_and_close_when_idle() {
+        let writer = MySqlItemWriter::<String>::new();
+
+        assert!(ItemWriter::<String>::flush(&writer).is_ok());
+        assert!(ItemWriter::<String>::close(&writer).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_delay_the_write_error_to_close_when_concurrent() {
+        use crate::BatchError;
+
+        // A lazy pool never connects until a query runs, so every dispatched
+        // write fails — without needing a database to fail against.
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy("mysql://nobody:nobody@127.0.0.1:1/nowhere")
+            .expect("a lazy pool is built without connecting");
+
+        let writer = MySqlItemWriter::<String>::new()
+            .with_concurrency(2)
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        assert!(
+            writer.write(&["a".to_string()]).is_ok(),
+            "a concurrent write is dispatched, not awaited, so it cannot fail here"
+        );
+
+        let closed = ItemWriter::<String>::close(&writer);
+        assert!(
+            closed.is_err(),
+            "close() drains, so the failed write must surface there"
+        );
+        match closed.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("MySQL"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_split_a_chunk_larger_than_the_bind_limit_when_concurrent() {
+        use crate::item::rdbc::writer_common::BIND_LIMIT;
+
+        let pool = sqlx::mysql::MySqlPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy("mysql://nobody:nobody@127.0.0.1:1/nowhere")
+            .expect("a lazy pool is built without connecting");
+
+        let writer = MySqlItemWriter::<String>::new()
+            .with_concurrency(2)
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        // One column, so the bind limit allows BIND_LIMIT rows per INSERT.
+        // Exceeding it must produce several INSERTs, exactly as the sequential
+        // path does, rather than one oversized statement.
+        let items = vec!["x".to_string(); BIND_LIMIT + 10];
+
+        assert!(
+            writer.write(&items).is_ok(),
+            "an oversized chunk must be split and dispatched, not rejected"
+        );
+        assert!(
+            ItemWriter::<String>::close(&writer).is_err(),
+            "the dead pool still fails every dispatched batch"
+        );
     }
 }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -186,16 +186,6 @@ impl<O> PostgresItemWriter<O> {
         table: &str,
         items: &[O],
     ) -> ItemWriterResult {
-        let rows: Vec<Vec<ColumnValue>> = items
-            .iter()
-            .map(|item| {
-                self.column_bindings
-                    .iter()
-                    .map(|(_, extractor)| extractor(item))
-                    .collect()
-            })
-            .collect();
-
         let col_list = self
             .column_bindings
             .iter()
@@ -203,30 +193,55 @@ impl<O> PostgresItemWriter<O> {
             .collect::<Vec<_>>()
             .join(",");
 
-        let pool = pool.clone();
-        let table_owned = table.to_string();
+        // Same bind-limit split as the sequential path: a chunk larger than the
+        // limit must become several INSERTs on both paths, or a chunk size that
+        // works sequentially would fail once concurrency is enabled.
+        let max_items = max_items_per_batch(self.column_bindings.len());
 
         let mut guard = self.inflight.borrow_mut();
         let inflight = guard.get_or_insert_with(|| {
             InflightWrites::new(self.concurrency, table.to_string(), "PostgreSQL")
         });
 
-        inflight.spawn(async move {
-            let mut query_builder = QueryBuilder::new("INSERT INTO ");
-            query_builder.push(&table_owned);
-            query_builder.push(" (");
-            query_builder.push(&col_list);
-            query_builder.push(") ");
-            // `into_iter` rather than `iter`: bind_column_value! moves the value
-            // out of the enum, so consuming the rows avoids a clone per column
-            // on the hot path.
-            query_builder.push_values(rows, |mut b, row| {
-                for value in row {
-                    bind_column_value!(b, value);
-                }
+        let mut first_error = Ok(());
+        for chunk in items.chunks(max_items) {
+            let batch: Vec<Vec<ColumnValue>> = chunk
+                .iter()
+                .map(|item| {
+                    self.column_bindings
+                        .iter()
+                        .map(|(_, extractor)| extractor(item))
+                        .collect()
+                })
+                .collect();
+
+            let pool = pool.clone();
+            let table_owned = table.to_string();
+            let col_list = col_list.clone();
+
+            let dispatched = inflight.spawn(async move {
+                let mut query_builder = QueryBuilder::new("INSERT INTO ");
+                query_builder.push(&table_owned);
+                query_builder.push(" (");
+                query_builder.push(&col_list);
+                query_builder.push(") ");
+                // `into_iter` rather than `iter`: bind_column_value! moves the value
+                // out of the enum, so consuming the rows avoids a clone per column
+                // on the hot path.
+                query_builder.push_values(batch, |mut b, row| {
+                    for value in row {
+                        bind_column_value!(b, value);
+                    }
+                });
+                query_builder.build().execute(&pool).await.map(|_| ())
             });
-            query_builder.build().execute(&pool).await.map(|_| ())
-        })
+
+            if dispatched.is_err() && first_error.is_ok() {
+                first_error = dispatched;
+            }
+        }
+
+        first_error
     }
 }
 
@@ -380,5 +395,36 @@ mod tests {
             BatchError::ItemWriter(msg) => assert!(msg.contains("PostgreSQL"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_split_a_chunk_larger_than_the_bind_limit_when_concurrent() {
+        use crate::item::rdbc::writer_common::BIND_LIMIT;
+
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy("postgresql://nobody:nobody@127.0.0.1:1/nowhere")
+            .expect("a lazy pool is built without connecting");
+
+        let writer = PostgresItemWriter::<String>::new()
+            .with_concurrency(2)
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        // One column, so the bind limit allows BIND_LIMIT rows per INSERT.
+        // Exceeding it must produce several INSERTs, exactly as the sequential
+        // path does, rather than one oversized statement.
+        let items = vec!["x".to_string(); BIND_LIMIT + 10];
+
+        assert!(
+            writer.write(&items).is_ok(),
+            "an oversized chunk must be split and dispatched, not rejected"
+        );
+        assert!(
+            ItemWriter::<String>::close(&writer).is_err(),
+            "the dead pool still fails every dispatched batch"
+        );
     }
 }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -1,8 +1,11 @@
+use std::cell::RefCell;
+
 use serde::Serialize;
 use sqlx::{Pool, Postgres, QueryBuilder};
 
 use crate::core::item::{ItemWriter, ItemWriterResult};
 use crate::item::rdbc::ColumnValue;
+use crate::item::rdbc::inflight_writes::InflightWrites;
 
 use super::writer_common::{
     bind_column_value, create_write_error, log_write_success, max_items_per_batch, validate_config,
@@ -46,6 +49,11 @@ pub struct PostgresItemWriter<O> {
     #[allow(clippy::type_complexity)]
     pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
     pub(crate) concurrency: usize,
+    /// In-flight writes, created on first concurrent write.
+    ///
+    /// The `Option` is lazy initialisation: the table name is not known until
+    /// `write` runs. Stays `None` for the sequential path.
+    pub(crate) inflight: RefCell<Option<InflightWrites>>,
 }
 
 impl<O> PostgresItemWriter<O> {
@@ -56,6 +64,7 @@ impl<O> PostgresItemWriter<O> {
             table: None,
             column_bindings: Vec::new(),
             concurrency: 1,
+            inflight: RefCell::new(None),
         }
     }
 
@@ -115,18 +124,16 @@ impl<O> Default for PostgresItemWriter<O> {
     }
 }
 
-impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
-    fn write(&self, items: &[O]) -> ItemWriterResult {
-        if items.is_empty() {
-            return Ok(());
-        }
-
-        let (pool, table) = validate_config(
-            self.pool.as_ref(),
-            self.table.as_deref(),
-            self.column_bindings.len(),
-        )?;
-
+impl<O> PostgresItemWriter<O> {
+    /// Writes the chunk with one blocking INSERT per bind-limited batch.
+    ///
+    /// This is the default path, taken whenever `concurrency <= 1`.
+    fn write_sequential(
+        &self,
+        pool: &Pool<Postgres>,
+        table: &str,
+        items: &[O],
+    ) -> ItemWriterResult {
         let col_names: Vec<&str> = self
             .column_bindings
             .iter()
@@ -161,6 +168,105 @@ impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
 
         log_write_success(items.len(), table, "PostgreSQL");
         Ok(())
+    }
+
+    /// Dispatches the chunk as a task, bounded by `concurrency`.
+    ///
+    /// Column values are extracted here, on the calling thread, because the
+    /// extractor closures are not `Send`. Only the resulting `ColumnValue`s —
+    /// which are `Send + 'static` — cross into the spawned task.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`BatchError::ItemWriter`](crate::BatchError::ItemWriter) if an
+    /// *earlier* write failed and was harvested while making room for this one.
+    fn write_concurrent(
+        &self,
+        pool: &Pool<Postgres>,
+        table: &str,
+        items: &[O],
+    ) -> ItemWriterResult {
+        let rows: Vec<Vec<ColumnValue>> = items
+            .iter()
+            .map(|item| {
+                self.column_bindings
+                    .iter()
+                    .map(|(_, extractor)| extractor(item))
+                    .collect()
+            })
+            .collect();
+
+        let col_list = self
+            .column_bindings
+            .iter()
+            .map(|(n, _)| n.as_str())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        let pool = pool.clone();
+        let table_owned = table.to_string();
+
+        let mut guard = self.inflight.borrow_mut();
+        let inflight = guard.get_or_insert_with(|| {
+            InflightWrites::new(self.concurrency, table.to_string(), "PostgreSQL")
+        });
+
+        inflight.spawn(async move {
+            let mut query_builder = QueryBuilder::new("INSERT INTO ");
+            query_builder.push(&table_owned);
+            query_builder.push(" (");
+            query_builder.push(&col_list);
+            query_builder.push(") ");
+            // `into_iter` rather than `iter`: bind_column_value! moves the value
+            // out of the enum, so consuming the rows avoids a clone per column
+            // on the hot path.
+            query_builder.push_values(rows, |mut b, row| {
+                for value in row {
+                    bind_column_value!(b, value);
+                }
+            });
+            query_builder.build().execute(&pool).await.map(|_| ())
+        })
+    }
+}
+
+impl<O: Serialize + Clone> ItemWriter<O> for PostgresItemWriter<O> {
+    fn write(&self, items: &[O]) -> ItemWriterResult {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        let (pool, table) = validate_config(
+            self.pool.as_ref(),
+            self.table.as_deref(),
+            self.column_bindings.len(),
+        )?;
+
+        if self.concurrency <= 1 {
+            return self.write_sequential(pool, table, items);
+        }
+
+        self.write_concurrent(pool, table, items)
+    }
+
+    /// Collects results of finished writes without waiting.
+    ///
+    /// Deliberately non-blocking: the step engine calls this after every chunk,
+    /// so waiting here would serialise the concurrent path back into sequence.
+    /// Always `Ok` on the sequential path, which keeps nothing in flight.
+    fn flush(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.harvest(),
+            None => Ok(()),
+        }
+    }
+
+    /// Waits for every in-flight write and reports the first failure.
+    fn close(&self) -> ItemWriterResult {
+        match self.inflight.borrow_mut().as_mut() {
+            Some(inflight) => inflight.drain(),
+            None => Ok(()),
+        }
     }
 }
 
@@ -216,6 +322,62 @@ mod tests {
         let result = writer.write(&["x".to_string()]);
         match result.err().unwrap() {
             BatchError::ItemWriter(msg) => assert!(msg.contains("pool"), "{msg}"),
+            e => panic!("expected ItemWriter, got {e:?}"),
+        }
+    }
+
+    // --- concurrency ---
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_take_the_sequential_path_when_concurrency_is_one() {
+        let writer = PostgresItemWriter::<String>::new();
+
+        // No pool configured: the sequential path must fail validation immediately
+        // rather than dispatching anything.
+        let result = writer.write(&["a".to_string()]);
+
+        assert!(result.is_err(), "no pool means validate_config must reject");
+        assert_eq!(writer.concurrency, 1);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_report_no_error_from_flush_and_close_when_idle() {
+        let writer = PostgresItemWriter::<String>::new();
+
+        assert!(ItemWriter::<String>::flush(&writer).is_ok());
+        assert!(ItemWriter::<String>::close(&writer).is_ok());
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn should_delay_the_write_error_to_close_when_concurrent() {
+        use crate::BatchError;
+
+        // A lazy pool never connects until a query runs, so every dispatched
+        // write fails — without needing a database to fail against.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .max_connections(2)
+            .acquire_timeout(std::time::Duration::from_millis(200))
+            .connect_lazy("postgresql://nobody:nobody@127.0.0.1:1/nowhere")
+            .expect("a lazy pool is built without connecting");
+
+        let writer = PostgresItemWriter::<String>::new()
+            .with_concurrency(2)
+            .pool(&pool)
+            .table("t")
+            .add_column_binding("v".to_string(), Box::new(|s: &String| s.as_str().into()));
+
+        assert!(
+            writer.write(&["a".to_string()]).is_ok(),
+            "a concurrent write is dispatched, not awaited, so it cannot fail here"
+        );
+
+        let closed = ItemWriter::<String>::close(&writer);
+        assert!(
+            closed.is_err(),
+            "close() drains, so the failed write must surface there"
+        );
+        match closed.err().unwrap() {
+            BatchError::ItemWriter(msg) => assert!(msg.contains("PostgreSQL"), "{msg}"),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
     }

--- a/src/item/rdbc/postgres_writer.rs
+++ b/src/item/rdbc/postgres_writer.rs
@@ -45,6 +45,7 @@ pub struct PostgresItemWriter<O> {
     pub(crate) table: Option<String>,
     #[allow(clippy::type_complexity)]
     pub(crate) column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+    pub(crate) concurrency: usize,
 }
 
 impl<O> PostgresItemWriter<O> {
@@ -54,7 +55,35 @@ impl<O> PostgresItemWriter<O> {
             pool: None,
             table: None,
             column_bindings: Vec::new(),
+            concurrency: 1,
         }
+    }
+
+    /// Returns how many chunk writes this writer may keep in flight at once.
+    ///
+    /// `1` — the default — means writes are sequential. See
+    /// [`RdbcItemWriterBuilder::with_concurrency`](crate::item::rdbc::RdbcItemWriterBuilder::with_concurrency).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    ///
+    /// let writer = RdbcItemWriterBuilder::<String>::new()
+    ///     .table("t")
+    ///     .column("v", |s: &String| s.as_str().into())
+    ///     .build_postgres();
+    ///
+    /// assert_eq!(writer.concurrency(), 1, "writes are sequential unless opted in");
+    /// ```
+    pub fn concurrency(&self) -> usize {
+        self.concurrency
+    }
+
+    /// Sets how many chunk writes may be in flight at once.
+    pub(crate) fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
     }
 
     /// Sets the database connection pool for the writer.

--- a/src/item/rdbc/unified_writer_builder.rs
+++ b/src/item/rdbc/unified_writer_builder.rs
@@ -102,6 +102,7 @@ pub struct RdbcItemWriterBuilder<O> {
     table: Option<String>,
     #[allow(clippy::type_complexity)]
     column_bindings: Vec<(String, Box<dyn Fn(&O) -> ColumnValue>)>,
+    concurrency: usize,
 }
 
 impl<O> RdbcItemWriterBuilder<O> {
@@ -113,6 +114,7 @@ impl<O> RdbcItemWriterBuilder<O> {
             sqlite_pool: None,
             table: None,
             column_bindings: Vec::new(),
+            concurrency: 1,
         }
     }
 
@@ -199,6 +201,48 @@ impl<O> RdbcItemWriterBuilder<O> {
         self
     }
 
+    /// Sets how many chunk writes may be in flight at once.
+    ///
+    /// Defaults to `1`, which keeps the sequential behaviour: each `write` call
+    /// completes its INSERT before returning. Values above `1` dispatch writes
+    /// concurrently over the connection pool, which changes two observable things:
+    ///
+    /// - Chunks are no longer written in order.
+    /// - A write error surfaces on a later `write` call, or at `close`, rather than
+    ///   the call that dispatched it. `skip_limit` therefore applies with a delay of
+    ///   up to `concurrency` chunks.
+    ///
+    /// Only PostgreSQL and MySQL honour this. SQLite serialises writes behind a
+    /// database-level lock, so [`build_sqlite`](Self::build_sqlite) ignores the setting
+    /// and logs a warning.
+    ///
+    /// Keep this at or below the connection pool size; extra tasks would only queue
+    /// waiting for a connection.
+    ///
+    /// # Arguments
+    /// * `concurrency` - Maximum number of chunk writes in flight. `0` is treated as `1`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use spring_batch_rs::item::rdbc::RdbcItemWriterBuilder;
+    /// use spring_batch_rs::item::rdbc::ColumnValue;
+    ///
+    /// struct Order { id: i32 }
+    ///
+    /// let writer = RdbcItemWriterBuilder::<Order>::new()
+    ///     .table("orders")
+    ///     .column("id", |o: &Order| ColumnValue::Int(o.id as i64))
+    ///     .with_concurrency(4)
+    ///     .build_postgres();
+    ///
+    /// assert_eq!(writer.concurrency(), 4);
+    /// ```
+    pub fn with_concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = concurrency;
+        self
+    }
+
     /// Adds a column mapping for the writer.
     ///
     /// The `extractor` closure is called once per item per write, and must return
@@ -250,7 +294,7 @@ impl<O> RdbcItemWriterBuilder<O> {
     /// # }
     /// ```
     pub fn build_postgres(self) -> PostgresItemWriter<O> {
-        let mut writer = PostgresItemWriter::new();
+        let mut writer = PostgresItemWriter::new().with_concurrency(self.concurrency);
 
         if let Some(pool) = self.postgres_pool {
             writer = writer.pool(&pool);
@@ -289,7 +333,7 @@ impl<O> RdbcItemWriterBuilder<O> {
     /// # }
     /// ```
     pub fn build_mysql(self) -> MySqlItemWriter<O> {
-        let mut writer = MySqlItemWriter::new();
+        let mut writer = MySqlItemWriter::new().with_concurrency(self.concurrency);
 
         if let Some(pool) = self.mysql_pool {
             writer = writer.pool(&pool);
@@ -328,6 +372,14 @@ impl<O> RdbcItemWriterBuilder<O> {
     /// # }
     /// ```
     pub fn build_sqlite(self) -> SqliteItemWriter<O> {
+        if self.concurrency > 1 {
+            log::warn!(
+                "with_concurrency({}) ignored for SQLite: writes are serialised by a \
+                 database-level lock, so concurrency would add no throughput",
+                self.concurrency
+            );
+        }
+
         let mut writer = SqliteItemWriter::new();
 
         if let Some(pool) = self.sqlite_pool {
@@ -505,5 +557,56 @@ mod tests {
             ),
             e => panic!("expected ItemWriter, got {e:?}"),
         }
+    }
+
+    // --- concurrency ---
+
+    #[test]
+    fn should_default_concurrency_to_one() {
+        let writer = RdbcItemWriterBuilder::<User>::new()
+            .table("items")
+            .column("id", |u: &User| ColumnValue::Int(u.id as i64))
+            .build_postgres();
+
+        assert_eq!(
+            writer.concurrency, 1,
+            "default must be sequential so nobody opts in by accident"
+        );
+    }
+
+    #[test]
+    fn should_carry_configured_concurrency_to_the_writer() {
+        let writer = RdbcItemWriterBuilder::<User>::new()
+            .table("items")
+            .column("id", |u: &User| ColumnValue::Int(u.id as i64))
+            .with_concurrency(4)
+            .build_postgres();
+
+        assert_eq!(writer.concurrency, 4);
+    }
+
+    #[test]
+    fn should_carry_configured_concurrency_to_the_mysql_writer() {
+        let writer = RdbcItemWriterBuilder::<User>::new()
+            .table("items")
+            .column("id", |u: &User| ColumnValue::Int(u.id as i64))
+            .with_concurrency(4)
+            .build_mysql();
+
+        assert_eq!(writer.concurrency, 4);
+    }
+
+    #[test]
+    fn should_force_sqlite_to_stay_sequential() {
+        let writer = RdbcItemWriterBuilder::<User>::new()
+            .table("items")
+            .column("id", |u: &User| ColumnValue::Int(u.id as i64))
+            .with_concurrency(8)
+            .build_sqlite();
+
+        // SqliteItemWriter has no concurrency field at all — this test asserts the
+        // builder compiles and yields a working writer, i.e. the setting is
+        // accepted and ignored rather than rejected.
+        assert!(writer.table.is_some());
     }
 }

--- a/tests/rdbc_postgres.rs
+++ b/tests/rdbc_postgres.rs
@@ -155,6 +155,68 @@ async fn write_items_to_database() -> Result<(), Error> {
     Ok(())
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn should_write_every_row_with_concurrency() -> Result<(), Error> {
+    const ROW_COUNT: usize = 10_000;
+
+    // Prepare container
+    let container = postgres::Postgres::default().start().await?;
+    let host_ip = container.get_host().await?;
+    let host_port = container.get_host_port_ipv4(5432).await?;
+
+    let connection_uri = format!("postgres://postgres:postgres@{}:{}", host_ip, host_port);
+    let pool = PgPool::connect(&connection_uri).await?;
+
+    sqlx::query(CREATE_CARS_TABLE_SQL).execute(&pool).await?;
+
+    // Prepare reader: a CSV large enough to span many chunks
+    let mut csv = String::from("year,make,model,description\n");
+    for i in 0..ROW_COUNT {
+        csv.push_str(&format!("2020,make-{i},model-{i},row-{i}\n"));
+    }
+    let reader = CsvItemReaderBuilder::<Car>::new()
+        .has_headers(true)
+        .from_reader(csv.as_bytes());
+
+    // Prepare writer with several chunk writes in flight
+    let writer = RdbcItemWriterBuilder::<Car>::new()
+        .postgres(&pool)
+        .table("cars")
+        .column("year", |c: &Car| c.year.into())
+        .column("make", |c: &Car| c.make.as_str().into())
+        .column("model", |c: &Car| c.model.as_str().into())
+        .column("description", |c: &Car| c.description.as_str().into())
+        .with_concurrency(4)
+        .build_postgres();
+
+    let processor = PassThroughProcessor::<Car>::new();
+
+    let step = StepBuilder::new("concurrent-write")
+        .chunk::<Car, Car>(500)
+        .reader(&reader)
+        .processor(&processor)
+        .writer(&writer)
+        .build();
+
+    let job = JobBuilder::new().start(&step).build();
+    assert!(job.run().is_ok(), "job must succeed");
+
+    let step_execution = job.get_step_execution("concurrent-write").unwrap();
+    assert_eq!(step_execution.status, StepStatus::Success);
+    assert_eq!(step_execution.write_error_count, 0);
+
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM cars")
+        .fetch_one(&pool)
+        .await?;
+
+    assert_eq!(
+        count, ROW_COUNT as i64,
+        "concurrent writes must not lose or duplicate rows"
+    );
+
+    Ok(())
+}
+
 // --- PostgresRdbcItemReader-specific tests (migrated from src/) ---
 
 use spring_batch_rs::item::rdbc::PostgresRdbcItemReader;


### PR DESCRIPTION
Opt-in .with_concurrency(N) on the PostgreSQL and MySQL writers, bounded by a JoinSet of in-flight tasks.

Follows from the phase profiling: steps 1 and 3 spend 82% and 66% of their time writing, sequentially, over a 10-connection pool used one chunk at a time. Overlapping read against write caps at 26%; cutting the dominant phase itself is the larger prize.

Two constraints shaped the design. flush() is called after every chunk, so it must not drain the in-flight tasks or the whole thing collapses back to sequential. And close() currently has its error swallowed by manage_error, which with writes in flight would let a step report Success after losing the final batch — so the engine must treat a failing close() as fatal.